### PR TITLE
Fix sqlite3 import

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@ import (
     "strconv"
     "strings"
     "time"
-    "IdenaAuthGo/agents" // If using modules; may need path adjustment
-    "github.com/mattn/go-sqlite3"
+    "idenauthgo/agents" // If using modules; may need path adjustment
+    _ "github.com/mattn/go-sqlite3"
     "github.com/ethereum/go-ethereum/crypto"
 )
 


### PR DESCRIPTION
## Summary
- fix `github.com/mattn/go-sqlite3` import as blank
- correct agents module path for build

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68428623606083208c54edabb9632269