### PR TITLE
Add basic tests and CI

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,17 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - run: go test ./...

--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@ import (
     "strconv"
     "strings"
     "time"
-    "IdenaAuthGo/agents" // If using modules; may need path adjustment
-    "github.com/mattn/go-sqlite3"
+    "idenauthgo/agents" // If using modules; may need path adjustment
+    _ "github.com/mattn/go-sqlite3"
     "github.com/ethereum/go-ethereum/crypto"
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func signMessage(priv *ecdsa.PrivateKey, msg string) string {
+	h := crypto.Keccak256(crypto.Keccak256([]byte(msg)))
+	sig, _ := crypto.Sign(h, priv)
+	return hex.EncodeToString(sig)
+}
+
+func TestVerifySignature(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(priv.PublicKey).Hex()
+	nonce := "test-nonce"
+	sigHex := signMessage(priv, nonce)
+	if !verifySignature(nonce, addr, sigHex) {
+		t.Fatalf("expected valid signature")
+	}
+	if verifySignature(nonce, addr, "deadbeef") {
+		t.Fatalf("expected invalid signature")
+	}
+}
+
+func TestGetIdentityRpc(t *testing.T) {
+	oldClient := http.DefaultClient
+	defer func() { http.DefaultClient = oldClient }()
+
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != idenaRpcUrl {
+			t.Fatalf("unexpected url %s", req.URL.String())
+		}
+		resp := map[string]interface{}{
+			"result": map[string]string{
+				"state": "Human",
+				"stake": "15000",
+			},
+		}
+		b, _ := json.Marshal(resp)
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(b)), Header: make(http.Header)}, nil
+	})}
+
+	state, stake := getIdentity("0xabc")
+	if state != "Human" || stake != 15000 {
+		t.Fatalf("unexpected result %s %.f", state, stake)
+	}
+}
+
+func TestGetIdentityFallback(t *testing.T) {
+	calls := 0
+	oldClient := http.DefaultClient
+	defer func() { http.DefaultClient = oldClient }()
+
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		switch req.URL.String() {
+		case idenaRpcUrl:
+			return &http.Response{StatusCode: 500, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+		case fallbackApiUrl + "/api/Identity/0xabc":
+			resp := map[string]interface{}{"result": map[string]string{"state": "Verified"}}
+			b, _ := json.Marshal(resp)
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(b)), Header: make(http.Header)}, nil
+		case fallbackApiUrl + "/api/Address/0xabc":
+			resp := map[string]interface{}{"result": map[string]string{"stake": "9000"}}
+			b, _ := json.Marshal(resp)
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(b)), Header: make(http.Header)}, nil
+		default:
+			t.Fatalf("unexpected url %s", req.URL.String())
+		}
+		return nil, nil
+	})}
+
+	state, stake := getIdentity("0xabc")
+	if state != "Verified" || stake != 9000 {
+		t.Fatalf("unexpected fallback result %s %.f", state, stake)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- fix agents import path in `main.go`
- add tests for `verifySignature` and `getIdentity`
- create GitHub Actions workflow to run `go test ./...`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6842862e91808320a46cce74fc43ddc4