### PR TITLE
Add tests for Merkle root computation

### DIFF
--- a/merkle_test.go
+++ b/merkle_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestComputeMerkleRootEmpty(t *testing.T) {
+	if res := computeMerkleRoot([]string{}); res != "" {
+		t.Fatalf("expected empty string, got %q", res)
+	}
+}
+
+func TestComputeMerkleRootKnown(t *testing.T) {
+	addrs := []string{
+		"0x0000000000000000000000000000000000000001",
+		"0x0000000000000000000000000000000000000002",
+		"0x0000000000000000000000000000000000000003",
+	}
+	got := computeMerkleRoot(addrs)
+	want := "839d9a6ca43af7a125e9ece32839c12217469d40453b82e8a46b91da964f1e03"
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- add `merkle_test.go` with test cases for `computeMerkleRoot`
- verify empty list handling and known output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842a72b49cc8320a79702578c4bf00e