### PR TITLE
Implement proof block collector

### DIFF
--- a/agents/block_collector.go
+++ b/agents/block_collector.go
@@ -1,0 +1,69 @@
+package agents
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+var httpClient = http.DefaultClient
+
+// fetchBlock retrieves a block by height using the bcn_block RPC method.
+func fetchBlock(nodeURL, apiKey string, height int) ([]json.RawMessage, error) {
+	req := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "bcn_block",
+		"params":  []interface{}{height},
+	}
+	if apiKey != "" {
+		req["key"] = apiKey
+	}
+	body, _ := json.Marshal(req)
+	httpReq, _ := http.NewRequest("POST", nodeURL, bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("rpc status %s", resp.Status)
+	}
+	var out struct {
+		Result struct {
+			Transactions []json.RawMessage `json:"transactions"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Result.Transactions, nil
+}
+
+// CollectShortAnswerTxs fetches blocks in the given height range and returns
+// all transactions of type ShortAnswersHashTx found in those blocks.
+func CollectShortAnswerTxs(nodeURL, apiKey string, startHeight, endHeight int) ([]json.RawMessage, error) {
+	var res []json.RawMessage
+	for h := startHeight; h <= endHeight; h++ {
+		txs, err := fetchBlock(nodeURL, apiKey, h)
+		if err != nil {
+			return nil, fmt.Errorf("fetch block %d: %w", h, err)
+		}
+		for _, raw := range txs {
+			var t struct {
+				Type     string `json:"type"`
+				TypeName string `json:"typeName"`
+			}
+			if err := json.Unmarshal(raw, &t); err != nil {
+				continue
+			}
+			if t.Type == "ShortAnswersHashTx" || t.TypeName == "ShortAnswersHashTx" {
+				// keep raw transaction for later processing
+				res = append(res, raw)
+			}
+		}
+	}
+	return res, nil
+}

--- a/agents/block_collector_test.go
+++ b/agents/block_collector_test.go
@@ -1,0 +1,59 @@
+package agents
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestCollectShortAnswerTxs(t *testing.T) {
+	blocks := map[int][]map[string]interface{}{
+		10: {
+			{"type": "ShortAnswersHashTx", "hash": "0x1"},
+			{"type": "SendTx", "hash": "0x2"},
+		},
+		11: {},
+	}
+
+	oldClient := httpClient
+	defer func() { httpClient = oldClient }()
+
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		bodyBytes, _ := io.ReadAll(req.Body)
+		var rpcReq struct {
+			Params []int `json:"params"`
+		}
+		_ = json.Unmarshal(bodyBytes, &rpcReq)
+		height := rpcReq.Params[0]
+		txs := blocks[height]
+		respBody, _ := json.Marshal(map[string]interface{}{
+			"result": map[string]interface{}{
+				"transactions": txs,
+			},
+		})
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(respBody)), Header: make(http.Header)}, nil
+	})}
+
+	txs, err := CollectShortAnswerTxs("http://node", "", 10, 11)
+	if err != nil {
+		t.Fatalf("collect error: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Fatalf("expected 1 tx, got %d", len(txs))
+	}
+	var tx map[string]interface{}
+	if err := json.Unmarshal(txs[0], &tx); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if tx["hash"] != "0x1" {
+		t.Fatalf("unexpected tx hash %v", tx["hash"])
+	}
+}


### PR DESCRIPTION
## Summary
- add a block collector to fetch ShortAnswersHashTx transactions
- test block collector with mocked RPC responses

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844bbd4eb48832080e8fd7f3673842f