### PR TITLE
Add whitelist extraction toolkit

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"idenauthgo/whitelist"
+)
+
+func main() {
+	txData, err := os.ReadFile("data/proof_txs.json")
+	if err != nil {
+		log.Fatalf("read txs: %v", err)
+	}
+	var txs []whitelist.Tx
+	if err := json.Unmarshal(txData, &txs); err != nil {
+		log.Fatalf("decode txs: %v", err)
+	}
+
+	addrs := whitelist.ExtractAddresses(txs)
+	if err := whitelist.SaveAddresses(addrs, "data/extracted_addresses.json"); err != nil {
+		log.Fatalf("save addresses: %v", err)
+	}
+
+	flips, err := whitelist.CheckFlipReports(addrs, "http://localhost:9009", "")
+	if err != nil {
+		log.Fatalf("flip check: %v", err)
+	}
+
+	status, err := whitelist.CheckIdentityStatus(addrs, flips, "http://localhost:9009", "")
+	if err != nil {
+		log.Fatalf("status check: %v", err)
+	}
+
+	wl := whitelist.BuildWhitelist(status)
+	if err := whitelist.SaveWhitelist(wl, "data/whitelist.json"); err != nil {
+		log.Fatalf("save whitelist: %v", err)
+	}
+}

--- a/whitelist/address_extractor.go
+++ b/whitelist/address_extractor.go
@@ -1,0 +1,44 @@
+package whitelist
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Tx represents a minimal transaction needed for extraction.
+type Tx struct {
+	From   string `json:"from"`
+	Author string `json:"author"`
+}
+
+// ExtractAddresses parses a list of transactions and returns a
+// deduplicated, sorted set of sender/author addresses.
+func ExtractAddresses(txs []Tx) []string {
+	set := make(map[string]struct{})
+	for _, tx := range txs {
+		if tx.From != "" {
+			set[strings.ToLower(tx.From)] = struct{}{}
+		}
+		if tx.Author != "" {
+			set[strings.ToLower(tx.Author)] = struct{}{}
+		}
+	}
+	addrs := make([]string, 0, len(set))
+	for a := range set {
+		addrs = append(addrs, a)
+	}
+	sort.Strings(addrs)
+	return addrs
+}
+
+// SaveAddresses writes the address list to disk as JSON.
+func SaveAddresses(addrs []string, path string) error {
+	sort.Strings(addrs)
+	b, err := json.MarshalIndent(addrs, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0644)
+}

--- a/whitelist/address_extractor_test.go
+++ b/whitelist/address_extractor_test.go
@@ -1,0 +1,21 @@
+package whitelist
+
+import "testing"
+
+func TestExtractAddresses(t *testing.T) {
+	txs := []Tx{
+		{From: "0x1", Author: "0xA"},
+		{From: "0x2", Author: "0xa"},
+		{From: "0x1", Author: ""},
+	}
+	got := ExtractAddresses(txs)
+	want := []string{"0x1", "0x2", "0xa"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d addrs, got %d", len(want), len(got))
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("want %s got %s", v, got[i])
+		}
+	}
+}

--- a/whitelist/builder.go
+++ b/whitelist/builder.go
@@ -1,0 +1,27 @@
+package whitelist
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+)
+
+// BuildWhitelist converts the status map into a sorted address slice.
+func BuildWhitelist(status map[string]string) []string {
+	list := make([]string, 0, len(status))
+	for addr := range status {
+		list = append(list, addr)
+	}
+	sort.Strings(list)
+	return list
+}
+
+// SaveWhitelist writes the whitelist to disk as JSON.
+func SaveWhitelist(addrs []string, path string) error {
+	sort.Strings(addrs)
+	b, err := json.MarshalIndent(addrs, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0644)
+}

--- a/whitelist/flip_checker.go
+++ b/whitelist/flip_checker.go
@@ -1,0 +1,16 @@
+package whitelist
+
+// Flip report checker queries each identity and marks those with penalties.
+
+func CheckFlipReports(addrs []string, nodeURL, apiKey string) (map[string]bool, error) {
+	res := make(map[string]bool)
+	for _, a := range addrs {
+		id, err := fetchIdentity(a, nodeURL, apiKey)
+		if err != nil {
+			return nil, err
+		}
+		reported := id.Penalty != "" && id.Penalty != "0"
+		res[a] = reported
+	}
+	return res, nil
+}

--- a/whitelist/rpc.go
+++ b/whitelist/rpc.go
@@ -1,0 +1,38 @@
+package whitelist
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type identityResp struct {
+	State   string `json:"state"`
+	Stake   string `json:"stake"`
+	Penalty string `json:"penalty"`
+}
+
+func fetchIdentity(addr, url, key string) (*identityResp, error) {
+	req := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "dna_identity",
+		"params":  []string{addr},
+		"id":      1,
+	}
+	if key != "" {
+		req["key"] = key
+	}
+	body, _ := json.Marshal(req)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Result identityResp `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out.Result, nil
+}

--- a/whitelist/status_checker.go
+++ b/whitelist/status_checker.go
@@ -1,0 +1,20 @@
+package whitelist
+
+// CheckIdentityStatus retrieves identity state for addresses not flagged for
+// reported flips.
+func CheckIdentityStatus(addrs []string, flips map[string]bool, nodeURL, apiKey string) (map[string]string, error) {
+	out := make(map[string]string)
+	for _, a := range addrs {
+		if flips[a] {
+			continue
+		}
+		id, err := fetchIdentity(a, nodeURL, apiKey)
+		if err != nil {
+			return nil, err
+		}
+		if id.State == "Human" || id.State == "Verified" || id.State == "Newbie" {
+			out[a] = id.State
+		}
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- add standalone whitelist builder modules
- extract and deduplicate addresses from transactions
- check identities for penalties and status
- provide simple orchestrator example
- test address extraction logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844bc2230f48320b14b2a9ea0c62689