### PR TITLE
Add session block finder agent

### DIFF
--- a/agents/session_block_finder.go
+++ b/agents/session_block_finder.go
@@ -1,0 +1,106 @@
+package agents
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Block represents a minimal subset of Idena block data used by the session finder.
+type Block struct {
+	Height int      `json:"height"`
+	Flags  []string `json:"flags"`
+}
+
+// blockResponse models the response format for /api/Block endpoints.
+type blockResponse struct {
+	Result Block `json:"result"`
+}
+
+// fetchBlock retrieves block data by height using the node's REST API.
+func fetchBlock(baseURL string, apiKey string, height int) (*Block, error) {
+	url := strings.TrimRight(baseURL, "/") + fmt.Sprintf("/api/Block/%d", height)
+	if apiKey != "" {
+		url += "?apikey=" + apiKey
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var br blockResponse
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return nil, err
+	}
+	return &br.Result, nil
+}
+
+// fetchLastBlock returns the latest block from the node.
+func fetchLastBlock(baseURL string, apiKey string) (*Block, error) {
+	url := strings.TrimRight(baseURL, "/") + "/api/Block/Last"
+	if apiKey != "" {
+		url += "?apikey=" + apiKey
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var br blockResponse
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return nil, err
+	}
+	return &br.Result, nil
+}
+
+// containsFlag checks whether a block has a specific flag set.
+func containsFlag(b *Block, flag string) bool {
+	for _, f := range b.Flags {
+		if f == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// FindSessionBlocks polls the node until it detects the ShortSessionStarted and
+// LongSessionStarted flags. It returns the block heights for both events.
+// The pollInterval controls how often the node is queried for new blocks.
+func FindSessionBlocks(baseURL, apiKey string, pollInterval time.Duration) (int, int, error) {
+	if pollInterval <= 0 {
+		pollInterval = 10 * time.Second
+	}
+
+	// Wait for ShortSessionStarted
+	var shortHeight int
+	for {
+		blk, err := fetchLastBlock(baseURL, apiKey)
+		if err != nil {
+			return 0, 0, err
+		}
+		if containsFlag(blk, "ShortSessionStarted") {
+			shortHeight = blk.Height
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	// After the short session block is seen, the long session flag should
+	// appear within the next few blocks.
+	var longHeight int
+	for {
+		blk, err := fetchLastBlock(baseURL, apiKey)
+		if err != nil {
+			return 0, 0, err
+		}
+		if blk.Height >= shortHeight && containsFlag(blk, "LongSessionStarted") {
+			longHeight = blk.Height
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	return shortHeight, longHeight, nil
+}

--- a/agents/session_block_finder_test.go
+++ b/agents/session_block_finder_test.go
@@ -1,0 +1,21 @@
+package agents
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBlockParsing(t *testing.T) {
+	data := `{"result":{"height":9285951,"flags":["ShortSessionStarted"]}}`
+	var br blockResponse
+	if err := json.NewDecoder(strings.NewReader(data)).Decode(&br); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if br.Result.Height != 9285951 {
+		t.Fatalf("expected height 9285951, got %d", br.Result.Height)
+	}
+	if !containsFlag(&br.Result, "ShortSessionStarted") {
+		t.Fatalf("flag not detected")
+	}
+}


### PR DESCRIPTION
## Summary
- create `Session Block Finder` module to detect short/long session blocks
- add unit test for block parsing

## Testing
- `go vet ./...`
- `go test ./agents -run TestBlockParsing -v`


------
https://chatgpt.com/codex/tasks/task_e_6844b918d8848320b936d1b411bdf707