### PR TITLE
Fix callback HTML content type

### DIFF
--- a/main.go
+++ b/main.go
@@ -461,6 +461,7 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[CALLBACK] Rendering HTML: Headline=%s, Message=%s", data.Headline, data.Message)
 	tmpl := mustLoadTemplate("templates/result.html")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	err = tmpl.Execute(w, data)
 	if err != nil {
 		log.Printf("[CALLBACK][ERROR] Template rendering failed: %v", err)


### PR DESCRIPTION
## Summary
- set `text/html` content type explicitly when rendering callback result page

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849538f783083209dba19e4f3a99e96