### PR TITLE
Improve callback HTML error page

### DIFF
--- a/main.go
+++ b/main.go
@@ -457,7 +457,20 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 	err := row.Scan(&address, &authenticated, &state, &stake)
 	if err != nil {
 		log.Printf("[CALLBACK] Token not found: %s", token)
-		http.Error(w, "Session not found", http.StatusNotFound)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+<html>
+  <head>
+    <title>Sign-in Error</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <h2>❌ Invalid or expired sign-in token</h2>
+    <p>Please try logging in again.</p>
+  </body>
+</html>
+`))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- add HTML response when `/callback` fails to find a session token

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684959be27c48320be09532a99896bdf