### PR TITLE
Fix result display after auth callback

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>{{.Headline}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="5; url={{.BaseUrl}}/" />
     <style>
         body { font-family: Arial, sans-serif; background: #f8fafc; color: #333; text-align: center; margin: 0; padding: 0;}
         .container { max-width: 400px; margin: 5% auto; padding: 2rem; background: #fff; border-radius: 18px; box-shadow: 0 2px 24px #e0e0e0;}
@@ -23,5 +24,12 @@
         </div>
     </div>
 </body>
+<script>
+  // Attempt to close the window when opened inside the Idena app
+  if (window.opener) {
+    window.opener.postMessage('idena-auth-complete', '*');
+    setTimeout(function() { window.close(); }, 1500);
+  }
+</script>
 </html>
 


### PR DESCRIPTION
## Summary
- initialize `resultTmpl` at startup and reuse it
- explicitly render the template in `callbackHandler`
- add auto-refresh and close logic to `result.html`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684a062fdca88320988abc979aed8d82