### PR TITLE
Fix nonce endpoint health check

### DIFF
--- a/main.go
+++ b/main.go
@@ -376,8 +376,9 @@ func startSessionHandler(w http.ResponseWriter, r *http.Request) {
 		token := r.URL.Query().Get("token")
 		addr := r.URL.Query().Get("address")
 		if token == "" || addr == "" {
-			log.Printf("[NONCE_ENDPOINT][GET] Missing token or address")
-			http.Error(w, "Bad request", http.StatusBadRequest)
+			log.Println("[NONCE_ENDPOINT][GET] Empty params – returning 200 OK for health-check")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("ok"))
 			return
 		}
 		nonce := "signin-" + randHex(16)


### PR DESCRIPTION
## Summary
- allow empty GET requests on `/auth/v1/start-session`
- return 200 OK with `ok` body for health-checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ac81b65408320824600a895f2ac21