### PR TITLE
Update health-check logic and add tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -375,10 +375,14 @@ func startSessionHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[NONCE_ENDPOINT][GET] Query: %v", r.URL.Query())
 		token := r.URL.Query().Get("token")
 		addr := r.URL.Query().Get("address")
-		if token == "" || addr == "" {
+		if token == "" && addr == "" {
 			log.Println("[NONCE_ENDPOINT][GET] Empty params – returning 200 OK for health-check")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("ok"))
+			return
+		}
+		if token == "" || addr == "" {
+			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
 		}
 		nonce := "signin-" + randHex(16)

--- a/main_test.go
+++ b/main_test.go
@@ -111,3 +111,21 @@ func TestStartSessionHandlerHealthCheck(t *testing.T) {
 		t.Fatalf("expected body 'ok', got %q", body)
 	}
 }
+
+func TestStartSessionHandlerMissingToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/auth/v1/start-session?address=0xabc", nil)
+	rr := httptest.NewRecorder()
+	startSessionHandler(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+}
+
+func TestStartSessionHandlerMissingAddress(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/auth/v1/start-session?token=123", nil)
+	rr := httptest.NewRecorder()
+	startSessionHandler(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- refine health check logic in `startSessionHandler`
- add tests for missing query parameters

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b19c555b08320b0dbf027131450cf