### PR TITLE
Fix default base URL to https

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 
 // Environment variables, with fallback for local/dev usage
 var (
-	BASE_URL      = getenv("BASE_URL", "http://proofofhuman.work")
+	BASE_URL      = getenv("BASE_URL", "https://proofofhuman.work")
 	IDENA_RPC_KEY = getenv("IDENA_RPC_KEY", "")
 )
 


### PR DESCRIPTION
## Summary
- use HTTPS for default `BASE_URL`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684bcf09a4508320b3d350c403dd8f3b