### PR TITLE
Fix login popup closing

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -25,10 +25,12 @@
     </div>
 </body>
 <script>
-  // Attempt to close the window when opened inside the Idena app
+  // Notify the opener that authentication has finished.
+  // Removed the automatic window.close() to allow users to stay on
+  // this page after login.
   if (window.opener) {
     window.opener.postMessage('idena-auth-complete', '*');
-    setTimeout(function() { window.close(); }, 1500);
+    // setTimeout(function() { window.close(); }, 1500);
   }
 </script>
 </html>


### PR DESCRIPTION
## Summary
- don't automatically close the result.html window after login

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684bd484678c8320bf98677d97eeae1b