### PR TITLE
Ensure callback always renders result page

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -15,9 +15,12 @@
 <body>
     <div class="container">
         <h1>{{.Headline}}</h1>
-        <div>{{
-            safeHTML .Message
-        }}</div>
+        {{if .Address}}
+        <p><b>Address:</b> {{.Address}}</p>
+        {{end}}
+        <p><b>Status:</b> {{if .State}}{{.State}}{{else}}Unknown{{end}}</p>
+        <p><b>Stake:</b> {{printf "%.3f" .Stake}}</p>
+        <p>{{safeHTML .Reason}}</p>
         <a href="{{.BaseUrl}}" class="btn">Continue to proofofhuman.work</a>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- improve result template to show address, state, stake and reason
- rewrite `callbackHandler` so all cases render the result page with logging

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684bf5143d3c8320b0f24bcd6fe879f1