### PR TITLE
Implement epoch-based whitelist logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ NOT USABLE RIGHT NOW! This project is a **work-in-progress** (WIP) Go backend fo
 
 - **Sign in with Idena:** Partial implementation of the deep-link flow (`/signin`, `/callback`) to authenticate users using the Idena app.
 - **Eligibility Check:** Evaluates identity state and stake (Human, Verified, or Newbie with ≥10,000 iDNA).
-- **Whitelist Endpoints:** `/whitelist` returns all eligible addresses; `/whitelist/check` verifies a single address.
+- **Whitelist Endpoints:** `/whitelist/current` returns the current epoch whitelist; `/whitelist/epoch/{epoch}` fetches a specific epoch; `/whitelist/check` verifies a single address.
 - **Merkle Root Endpoint:** Planned endpoint `/merkle_root` to return the Merkle root of the whitelist (not yet implemented).
 - **Identity Indexer:** `rolling_indexer/` polls identity data from an Idena node, stores to SQLite (`identities.db`), and serves JSON over HTTP. (⚠️ currently broken — needs debugging).
 - **Agent Scripts:** `agents/identity_fetcher.go` fetches identities by address list (configurable via `agents/fetcher_config.example.json`), useful for bootstrapping indexer data.
@@ -59,7 +59,9 @@ Available routes include:
 
     /callback – handles return from the Idena app
 
-    /whitelist – returns eligible addresses from DB
+    /whitelist/current – whitelist for the active epoch
+
+    /whitelist/epoch/{epoch} – whitelist for a specific epoch
 
     /whitelist/check?address=... – checks one address
 


### PR DESCRIPTION
## Summary
- snapshot whitelists for each Idena epoch
- store current epoch in DB and rebuild whitelist on epoch change
- expose `/whitelist/current` and `/whitelist/epoch/{epoch}` endpoints
- update README with new whitelist API usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684bfb326df483208996f78162badf47