### PR TITLE
Improve whitelist generation and loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ cp .env.example .env
 export BASE_URL="http://localhost:3030"
 export IDENA_RPC_KEY="your_idena_rpc_key"
 
+### Optional: Populate `address_list.json`
+
+Some endpoints use an address whitelist located at `data/address_list.json`.
+If this file is missing you can generate it with the strict builder utility:
+
+```bash
+go run cmd/strictbuilder/main.go
+```
+
+The command writes a clean JSON array of addresses. Alternatively you may run
+`whitelist_blueprint/build_idena_identities_strict.py` from the original
+blueprint and convert its output with `jq`:
+
+```bash
+python whitelist_blueprint/build_idena_identities_strict.py
+jq -r .address idena_strict_whitelist.jsonl | jq -R -s -c 'split("\n")[:-1]' > data/address_list.json
+```
+
+Running your own indexer is recommended for production setups.
+
 ### 4. Run the Web Server
 
 

--- a/agents/address_loader.go
+++ b/agents/address_loader.go
@@ -1,0 +1,51 @@
+package agents
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadAddressList reads addresses from a JSON or text file.
+// For .json files it expects an array of strings. For .txt it
+// accepts one address per line, ignoring blanks and comments.
+// Invalid lines are skipped with a warning.
+func LoadAddressList(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var addrs []string
+	ext := filepath.Ext(path)
+	if ext == ".json" {
+		var arr []string
+		if err := json.Unmarshal(data, &arr); err == nil {
+			for _, a := range arr {
+				a = strings.TrimSpace(a)
+				if strings.HasPrefix(a, "0x") && len(a) == 42 {
+					addrs = append(addrs, a)
+				} else if a != "" {
+					log.Printf("[AddressLoader] skip invalid address: %s", a)
+				}
+			}
+			return addrs, nil
+		}
+		// fallthrough to text parsing if JSON fails
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "0x") && len(line) == 42 {
+			addrs = append(addrs, line)
+		} else {
+			log.Printf("[AddressLoader] skip invalid line: %s", line)
+		}
+	}
+	return addrs, nil
+}

--- a/agents/address_loader_test.go
+++ b/agents/address_loader_test.go
@@ -1,0 +1,35 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAddressListTxt(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "list.txt")
+	data := "# comment\n0x0000000000000000000000000000000000000001\nbad\n0x0000000000000000000000000000000000000002\n"
+	os.WriteFile(f, []byte(data), 0644)
+	addrs, err := LoadAddressList(f)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(addrs))
+	}
+}
+
+func TestLoadAddressListJSON(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "list.json")
+	data := `["0x0000000000000000000000000000000000000001", "", "bad", "0x0000000000000000000000000000000000000002"]`
+	os.WriteFile(f, []byte(data), 0644)
+	addrs, err := LoadAddressList(f)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(addrs))
+	}
+}

--- a/agents/identity_fetcher.go
+++ b/agents/identity_fetcher.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -41,25 +40,6 @@ func LoadFetcherConfig(configPath string) (*FetcherConfig, error) {
 	}
 	log.Printf("[AGENT][Fetcher] Config loaded: %+v", cfg)
 	return &cfg, nil
-}
-
-// Load list of addresses from file (one per line), print debug info
-func LoadAddressList(path string) ([]string, error) {
-	log.Printf("[AGENT][Fetcher] Loading address list from: %s", path)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		log.Printf("[AGENT][Fetcher] Error reading address list: %v", err)
-		return nil, err
-	}
-	lines := []string{}
-	for _, line := range strings.Split(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" {
-			lines = append(lines, trimmed)
-		}
-	}
-	log.Printf("[AGENT][Fetcher] Loaded %d addresses", len(lines))
-	return lines, nil
 }
 
 // Fetch identity details from node; log raw response and decoded result

--- a/agents/identity_status_checker_test.go
+++ b/agents/identity_status_checker_test.go
@@ -18,8 +18,8 @@ func TestCheckIdentityStatuses(t *testing.T) {
 	dir := t.TempDir()
 	addrFile := filepath.Join(dir, "addresses.txt")
 	flipFile := filepath.Join(dir, "flips.txt")
-	os.WriteFile(addrFile, []byte("0x1\n0x2\n"), 0644)
-	os.WriteFile(flipFile, []byte("0x2\n"), 0644)
+	os.WriteFile(addrFile, []byte("0x0000000000000000000000000000000000000001\n0x0000000000000000000000000000000000000002\n"), 0644)
+	os.WriteFile(flipFile, []byte("0x0000000000000000000000000000000000000002\n"), 0644)
 
 	oldClient := http.DefaultClient
 	defer func() { http.DefaultClient = oldClient }()
@@ -44,7 +44,7 @@ func TestCheckIdentityStatuses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(list) != 1 || list[0].Address != "0x1" {
+	if len(list) != 1 || list[0].Address != "0x0000000000000000000000000000000000000001" {
 		t.Fatalf("unexpected result: %+v", list)
 	}
 }

--- a/cmd/strictbuilder/main.go
+++ b/cmd/strictbuilder/main.go
@@ -13,6 +13,7 @@ import (
 const (
 	addressFile           = "data/allAddresses.txt"
 	outFile               = "data/idena_whitelist.jsonl"
+	addressListOut        = "data/address_list.json"
 	stakeThresholdFile    = "data/discriminationStakeThreshold.txt"
 	newbieMinStake        = 10000.0
 	verifiedMinStake      = 10000.0
@@ -235,6 +236,7 @@ func main() {
 		return
 	}
 	defer out.Close()
+	var addrList []string
 	whitelisted := 0
 	for i, addr := range addrs {
 		addrL := strings.ToLower(addr)
@@ -277,9 +279,18 @@ func main() {
 		})
 		out.Write(data)
 		out.Write([]byte("\n"))
+		addrList = append(addrList, strings.ToLower(addr))
 		whitelisted++
 		fmt.Printf("[%d/%d] OK: %s state=%s stake=%.4f\n", i+1, len(addrs), addr, sum.State, stake)
 		time.Sleep(200 * time.Millisecond)
 	}
+	out2, err := os.Create(addressListOut)
+	if err != nil {
+		fmt.Println("write address list:", err)
+		return
+	}
+	b, _ := json.MarshalIndent(addrList, "", "  ")
+	out2.Write(b)
+	out2.Close()
 	fmt.Printf("Done. Whitelisted: %d addresses\n", whitelisted)
 }


### PR DESCRIPTION
## Summary
- add flexible `LoadAddressList` that supports `.json` or `.txt`
- output a clean JSON array in `cmd/strictbuilder`
- drop unused import from identity_fetcher
- document generating `address_list.json`
- test address loader and update existing tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fdb3fc55c83209a3c126794da3c1d