### PR TITLE
Improve eligibility checker UX and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NOT USABLE RIGHT NOW! This project is a **work-in-progress** (WIP) Go backend fo
 ## Current Features
 
 - **Sign in with Idena:** Partial implementation of the deep-link flow (`/signin`, `/callback`) to authenticate users using the Idena app.
-- **Eligibility Check:** Evaluates identity state and stake (Human, Verified, or Newbie with ≥10,000 iDNA).
+ - **Eligibility Check:** Evaluates identity state and stake. Humans must meet the dynamic discrimination stake threshold, while Verified or Newbie identities need at least 10,000 iDNA.
 - **Whitelist Endpoints:** `/whitelist/current` returns the current epoch whitelist; `/whitelist/epoch/{epoch}` fetches a specific epoch; `/whitelist/check` verifies a single address.
 - **Penalty Exclusion:** Addresses with a validation penalty in the current epoch are automatically excluded from the whitelist.
 - **Merkle Root Endpoint:** Planned endpoint `/merkle_root` to return the Merkle root of the whitelist (not yet implemented).
@@ -18,7 +18,7 @@ NOT USABLE RIGHT NOW! This project is a **work-in-progress** (WIP) Go backend fo
 - **Fix and Run Indexer:** Resolve merge conflicts and logic bugs in `rolling_indexer/main.go`; validate endpoints `/identities/latest`, `/eligible`, etc.
 - **Feed Identity Data:** Use agent scripts or direct RPC calls to populate the identity indexer database.
 - **Build Merkle Tree Generator:** Create the `/merkle_root` endpoint that returns a SHA256-based Merkle root of eligible addresses.
-- **Apply Eligibility Criteria:** Ensure consistent rules (state ∈ {Human, Verified, Newbie} && stake ≥ 10,000) across frontend and backend.
+ - **Apply Eligibility Criteria:** Ensure consistent rules (Human stake ≥ dynamic threshold, Verified/Newbie stake ≥ 10,000) across frontend and backend.
 - **Update `AGENTS.md`:** Either populate with actual working agents or simplify it to reflect current usage only.
 - **Code Cleanup & Tests:** Add tests, remove stale comments/conflicts, and improve error handling.
 

--- a/static/index.html
+++ b/static/index.html
@@ -62,6 +62,22 @@
     .btn-primary:hover {
       background: linear-gradient(90deg, #348ffe 30%, #2261a6 100%);
     }
+    .btn-secondary {
+      display: block;
+      width: 100%;
+      margin: 8px 0;
+      background: #4a4d52;
+      color: #fff;
+      padding: 12px 0;
+      border: none;
+      border-radius: 8px;
+      font-size: 1em;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    .btn-secondary:hover {
+      background: #5a5d62;
+    }
     .meta {
       font-size: 0.99em;
       color: #9eb2c5;
@@ -99,14 +115,16 @@
   <div class="container">
     <div class="card">
       <h1>Eligibility Checker</h1>
-      <p>Check an address or sign in with Idena.</p>
+      <p>Enter an address to see if it qualifies for group access.</p>
       <input id="addr" type="text" placeholder="0x..." style="width:100%;padding:12px;border-radius:8px;border:1px solid #555;background:#2b2e34;color:#fff;" />
       <button class="btn-primary" onclick="checkAddr()">Check address</button>
-      <button class="btn-primary" onclick="signinFallback()">Sign in with Idena</button>
+      <pre id="result" style="white-space:pre-wrap;margin:8px 0 0 0;"></pre>
+      <button class="btn-secondary" onclick="signinFallback()">Sign in with Idena</button>
       <div class="meta">
-        <div>Current setting:</div>
-        <div>• Must be: <strong>Human, Verified, or Newbie</strong></div>
-        <div>• Must have: <strong id="stake-info">10,000+</strong> IDNA at stake</div>
+        <div>Eligibility rules:</div>
+        <div>• Human: stake ≥ <strong id="human-threshold">...</strong> IDNA</div>
+        <div>• Verified/Newbie: stake ≥ <strong>10,000</strong> IDNA</div>
+        <div>• Identities with failed validations or banned status are not eligible.</div>
       </div>
     </div>
     <a class="github-link" href="https://github.com/ubiubi18/IdenaAuthGo" target="_blank" rel="noopener">Source on GitHub</a>
@@ -120,14 +138,25 @@
 <script>
 function checkAddr() {
   const a = document.getElementById('addr').value.trim();
-  if(!a) { signinFallback(); return; }
-  fetch('/whitelist/check?address='+a).then(r=>r.json()).then(res=>{
-    alert(res.eligible ? 'Eligible!' : 'Not eligible');
-  });
+  if(!a) { document.getElementById('result').textContent = 'Enter an address'; return; }
+  fetch('/whitelist/check?address='+a)
+    .then(r=>r.json())
+    .then(res=>{
+      const lines = [];
+      lines.push(res.eligible ? '✅ Eligible' : '❌ Not eligible');
+      if(res.state) lines.push('Identity: '+res.state);
+      if(typeof res.stake === 'number') lines.push('Stake: '+res.stake.toLocaleString('en-US')+' IDNA');
+      if(res.reason) lines.push('Reason: '+res.reason);
+      document.getElementById('result').textContent = lines.join('\n');
+    })
+    .catch(()=>{ document.getElementById('result').textContent = 'Error checking address'; });
 }
 function signinFallback() {
   window.location = '/signin';
 }
-fetch('/merkle_root').then(r=>r.json()).then(()=>{});
+fetch('/api/Epoch/Last').then(r=>r.json()).then(d=>{
+  const thr = parseFloat(d.result.discriminationStakeThreshold);
+  document.getElementById('human-threshold').textContent = Math.round(thr).toLocaleString();
+});
 </script>
 </html>

--- a/whitelist_check_test.go
+++ b/whitelist_check_test.go
@@ -1,43 +1,67 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"strings"
 	"testing"
 )
 
-// Test that the whitelistCheckHandler returns a descriptive error when the
-// whitelist file is missing or contains invalid JSON.
-func TestWhitelistCheckHandlerSnapshotErrors(t *testing.T) {
+func TestWhitelistCheckHandlerEligible(t *testing.T) {
 	setupTestDB(t)
 	defer db.Close()
 
-	// no snapshot file should produce an internal error
+	identityFetcher = func(addr string) (string, float64) {
+		return "Human", 7000
+	}
+	stakeThreshold = 6000
+	defer func() { identityFetcher = getIdentity }()
+
 	req := httptest.NewRequest("GET", "/whitelist/check?address=0xabc", nil)
 	rr := httptest.NewRecorder()
 	whitelistCheckHandler(rr, req)
-	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 for missing snapshot, got %d", rr.Code)
-	}
-	if !strings.Contains(rr.Body.String(), "no such file") {
-		t.Fatalf("unexpected body: %s", rr.Body.String())
-	}
 
-	// now create a malformed snapshot file
-	os.MkdirAll("data", 0755)
-	path := "data/snapshot.json"
-	os.WriteFile(path, []byte("{"), 0644)
-	defer os.Remove(path)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out struct {
+		Eligible bool    `json:"eligible"`
+		State    string  `json:"state"`
+		Stake    float64 `json:"stake"`
+		Rule     string  `json:"rule"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.Eligible || out.State != "Human" || out.Stake != 7000 || out.Rule == "" {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+}
 
-	rr = httptest.NewRecorder()
+func TestWhitelistCheckHandlerNotEligible(t *testing.T) {
+	setupTestDB(t)
+	defer db.Close()
+
+	identityFetcher = func(addr string) (string, float64) {
+		return "Suspended", 5000
+	}
+	defer func() { identityFetcher = getIdentity }()
+
+	req := httptest.NewRequest("GET", "/whitelist/check?address=0xdef", nil)
+	rr := httptest.NewRecorder()
 	whitelistCheckHandler(rr, req)
-	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 for malformed snapshot, got %d", rr.Code)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
 	}
-	body := rr.Body.String()
-	if !strings.Contains(body, "invalid character") && !strings.Contains(body, "unexpected end") {
-		t.Fatalf("unexpected body: %s", body)
+	var out struct {
+		Eligible bool   `json:"eligible"`
+		Reason   string `json:"reason"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Eligible || out.Reason == "" {
+		t.Fatalf("unexpected output: %+v", out)
 	}
 }


### PR DESCRIPTION
## Summary
- update frontend layout to prioritize address checking
- display dynamic Human stake threshold
- fetch identity data in `/whitelist/check` and return detailed reason
- add tests for new eligibility responses
- document new rules in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685020f68cb48320975d85f4359d0889