### PR TITLE
Use epoch snapshot for eligibility checks

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -150,6 +150,9 @@ func setupTestDB(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	createSessionTable()
+	createEpochSnapshotTable()
+	createPenaltyTable()
+	createMerkleRootTable()
 	resultTmpl = mustLoadTemplate("templates/result.html")
 }
 

--- a/whitelist_check_test.go
+++ b/whitelist_check_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -11,11 +12,16 @@ func TestWhitelistCheckHandlerEligible(t *testing.T) {
 	setupTestDB(t)
 	defer db.Close()
 
+	stakeThreshold = 6000
+	currentEpoch = 1
 	identityFetcher = func(addr string) (string, float64) {
 		return "Human", 7000
 	}
-	stakeThreshold = 6000
 	defer func() { identityFetcher = getIdentity }()
+	_, err := db.Exec(`INSERT INTO epoch_identity_snapshot(epoch,address,state,stake,penalized,flipReported) VALUES (1,'0xabc','Human',7000,0,0)`)
+	if err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
 
 	req := httptest.NewRequest("GET", "/whitelist/check?address=0xabc", nil)
 	rr := httptest.NewRecorder()
@@ -29,11 +35,12 @@ func TestWhitelistCheckHandlerEligible(t *testing.T) {
 		State    string  `json:"state"`
 		Stake    float64 `json:"stake"`
 		Rule     string  `json:"rule"`
+		Hint     string  `json:"hint"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !out.Eligible || out.State != "Human" || out.Stake != 7000 || out.Rule == "" {
+	if !out.Eligible || out.State != "Human" || out.Stake != 7000 || out.Rule != "snapshot" || !strings.Contains(out.Hint, "6000") {
 		t.Fatalf("unexpected output: %+v", out)
 	}
 }
@@ -42,10 +49,15 @@ func TestWhitelistCheckHandlerNotEligible(t *testing.T) {
 	setupTestDB(t)
 	defer db.Close()
 
+	currentEpoch = 1
 	identityFetcher = func(addr string) (string, float64) {
 		return "Suspended", 5000
 	}
 	defer func() { identityFetcher = getIdentity }()
+	_, err := db.Exec(`INSERT INTO epoch_identity_snapshot(epoch,address,state,stake,penalized,flipReported) VALUES (1,'0xdef','Suspended',5000,0,0)`)
+	if err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
 
 	req := httptest.NewRequest("GET", "/whitelist/check?address=0xdef", nil)
 	rr := httptest.NewRecorder()
@@ -57,11 +69,12 @@ func TestWhitelistCheckHandlerNotEligible(t *testing.T) {
 	var out struct {
 		Eligible bool   `json:"eligible"`
 		Reason   string `json:"reason"`
+		Hint     string `json:"hint"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Eligible || out.Reason == "" {
+	if out.Eligible || out.Reason == "" || !strings.Contains(out.Hint, "6000") {
 		t.Fatalf("unexpected output: %+v", out)
 	}
 }


### PR DESCRIPTION
## Summary
- update `whitelistCheckHandler` to use stored snapshot data
- add helper to fetch snapshot entries
- update tests and DB setup
- provide live hint for next epoch eligibility

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685118f11b588320b62280a7b7433daa