### PR TITLE
Add persisted snapshot eligibility endpoint

### DIFF
--- a/eligibility_handler_test.go
+++ b/eligibility_handler_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEligibilitySnapshotHandlerNoSnapshot(t *testing.T) {
+	setupTestDB(t)
+	defer db.Close()
+
+	req := httptest.NewRequest("GET", "/eligibility?address=0xabc", nil)
+	rr := httptest.NewRecorder()
+	eligibilitySnapshotHandler(rr, req)
+
+	var out EligibilityResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Reason == "" || out.Epoch != 0 {
+		t.Fatalf("unexpected: %+v", out)
+	}
+}
+
+func TestEligibilitySnapshotHandlerEligible(t *testing.T) {
+	setupTestDB(t)
+	defer db.Close()
+
+	stakeThreshold = 6000
+	saveSnapshotMeta(1, 123)
+	_, err := db.Exec(`INSERT INTO epoch_identity_snapshot(epoch,address,state,stake,penalized,flipReported) VALUES (1,'0xabc','Human',7000,0,0)`)
+	if err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/eligibility?address=0xabc", nil)
+	rr := httptest.NewRecorder()
+	eligibilitySnapshotHandler(rr, req)
+
+	var out EligibilityResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.Eligible || out.State != "Human" || out.Epoch != 1 || out.Block != 123 {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+}

--- a/finalization_watcher.go
+++ b/finalization_watcher.go
@@ -77,6 +77,7 @@ func watchEpochFinalization() {
 				currentEpoch = epoch
 				wlMu.Unlock()
 				setConfigInt("current_epoch", epoch)
+				saveSnapshotMeta(epoch, blk.Height)
 				last = epoch
 			}
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -151,6 +151,7 @@ func setupTestDB(t *testing.T) {
 	}
 	createSessionTable()
 	createEpochSnapshotTable()
+	createSnapshotMetaTable()
 	createPenaltyTable()
 	createMerkleRootTable()
 	resultTmpl = mustLoadTemplate("templates/result.html")


### PR DESCRIPTION
## Summary
- add `eligibilitySnapshotHandler` endpoint returning data from `epoch_identity_snapshot`
- store snapshot block per epoch and create new table `epoch_snapshot_meta`
- expose new response struct `EligibilityResponse`
- save snapshot metadata when whitelist is built
- test snapshot eligibility handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851223bd0f88320965b6bec9b292e50