### PR TITLE
Add next epoch eligibility prediction

### DIFF
--- a/eligibility_handler_test.go
+++ b/eligibility_handler_test.go
@@ -10,6 +10,9 @@ func TestEligibilitySnapshotHandlerNoSnapshot(t *testing.T) {
 	setupTestDB(t)
 	defer db.Close()
 
+	identityFetcher = func(addr string) (string, float64) { return "", 0 }
+	defer func() { identityFetcher = getIdentity }()
+
 	req := httptest.NewRequest("GET", "/eligibility?address=0xabc", nil)
 	rr := httptest.NewRecorder()
 	eligibilitySnapshotHandler(rr, req)
@@ -27,6 +30,9 @@ func TestEligibilitySnapshotHandlerEligible(t *testing.T) {
 	setupTestDB(t)
 	defer db.Close()
 
+	identityFetcher = func(addr string) (string, float64) { return "Human", 7000 }
+	defer func() { identityFetcher = getIdentity }()
+
 	stakeThreshold = 6000
 	saveSnapshotMeta(1, 123)
 	_, err := db.Exec(`INSERT INTO epoch_identity_snapshot(epoch,address,state,stake,penalized,flipReported) VALUES (1,'0xabc','Human',7000,0,0)`)
@@ -42,7 +48,7 @@ func TestEligibilitySnapshotHandlerEligible(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !out.Eligible || out.State != "Human" || out.Epoch != 1 || out.Block != 123 {
+	if !out.Eligible || out.State != "Human" || out.Epoch != 1 || out.Block != 123 || out.Prediction != "eligible both epochs" {
 		t.Fatalf("unexpected output: %+v", out)
 	}
 }


### PR DESCRIPTION
## Summary
- add Prediction field to EligibilityResponse
- provide new `predictNextEpoch` helper
- return prediction info from `/eligibility`
- cover new logic in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68512591eadc83208ffe07a919f8fa99