### PR TITLE
Improve eligibility UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ NOT USABLE RIGHT NOW! This project is a **work-in-progress** (WIP) Go backend fo
 - **Sign in with Idena:** Partial implementation of the deep-link flow (`/signin`, `/callback`) to authenticate users using the Idena app.
 ** **Eligibility Check:** Evaluates identity state and stake. Humans must meet the dynamic discrimination stake threshold, while Verified or Newbie identities need at least 10,000 iDNA.
 - **Whitelist Endpoints:** `/whitelist/current` returns the current epoch whitelist; `/whitelist/epoch/{epoch}` fetches a specific epoch; `/whitelist/check` verifies a single address.
+- **Eligibility Snapshot:** `/eligibility?address=...` shows eligibility as of the snapshot epoch/block and predicts the next epoch.
 - **Penalty Exclusion:** Addresses with a validation penalty in the current epoch are automatically excluded from the whitelist.
 - **Merkle Root Endpoint:** `/merkle_root` returns the Merkle root of the current whitelist and `/merkle_proof` yields proofs.
 - **Identity Indexer:** `rolling_indexer/` polls identity data from an Idena node, stores to SQLite (`identities.db`), and serves JSON over HTTP. (⚠️ currently broken — needs debugging).
@@ -85,11 +86,12 @@ Available routes include:
     /whitelist/epoch/{epoch} – whitelist for a specific epoch
 
     /whitelist/check?address=... – checks one address
+    /eligibility?address=... – eligibility as of the snapshot
 
 Example:
 
 ```bash
-curl -X GET "http://localhost:3030/whitelist/check?address=0xYourAddress"
+curl -X GET "http://localhost:3030/eligibility?address=0xYourAddress"
 ```
 
     /merkle_root – current epoch Merkle root

--- a/static/index.html
+++ b/static/index.html
@@ -120,7 +120,7 @@
       <p>Check an address or sign in with Idena.</p>
       <input id="addr" type="text" placeholder="0x..." style="width:100%;padding:12px;border-radius:8px;border:1px solid #555;background:#2b2e34;color:#fff;" />
       <button class="btn-primary" onclick="checkAddr()">Check address</button>
-      <pre id="result" style="white-space:pre-wrap;margin:8px 0 0 0;"></pre>
+      <div id="result" style="white-space:pre-wrap;margin:8px 0 0 0;"></div>
       <a href="/signin" class="signin-link">Sign in with Idena</a>
       <ul class="rules">
         <li>Must be <strong>Human</strong>, <strong>Verified</strong>, or <strong>Newbie</strong></li>
@@ -138,18 +138,27 @@
 <script>
 function checkAddr() {
   const a = document.getElementById('addr').value.trim();
-  if(!a) { document.getElementById('result').textContent = 'Enter an address'; return; }
-  fetch('/whitelist/check?address='+a)
+  const result = document.getElementById('result');
+  if(!a) { result.textContent = 'Enter an address'; return; }
+  result.textContent = 'Checking...';
+  fetch('/eligibility?address='+a)
     .then(r=>r.json())
     .then(res=>{
       const lines = [];
-      lines.push(res.eligible ? '✅ Eligible' : '❌ Not eligible');
+      lines.push(`Eligibility as of epoch ${res.epoch}, block ${res.block}:`);
+      lines.push(res.eligible ? '<span style="color:#7bf27b">✅ Eligible</span>' : '<span style="color:#ff6b6b">❌ Not eligible</span>');
       if(res.state) lines.push('Identity: '+res.state);
       if(typeof res.stake === 'number') lines.push('Stake: '+res.stake.toLocaleString('en-US')+' IDNA');
       if(res.reason) lines.push('Reason: '+res.reason);
-      document.getElementById('result').textContent = lines.join('\n');
+      if(res.prediction){
+        const warn = res.prediction.includes('not next');
+        let line = 'Next epoch prediction: '+res.prediction;
+        if(warn) line = '<span style="color:#ffd860">'+line+'</span>';
+        lines.push(warn? '⚠️ '+line : line);
+      }
+      result.innerHTML = lines.join('<br>');
     })
-    .catch(()=>{ document.getElementById('result').textContent = 'Error checking address'; });
+    .catch(()=>{ result.textContent = 'Error checking address'; });
 }
 fetch('/api/Epoch/Last').then(r=>r.json()).then(d=>{
   const thr = parseFloat(d.result.discriminationStakeThreshold);


### PR DESCRIPTION
## Summary
- show epoch/block in eligibility results
- mention new `/eligibility` endpoint in docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685128a4e81083208d33c5a8870cbe14