### PR TITLE
Add frontend backend integration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,7 +1,20 @@
 # Frontend
 
-This directory contains a simple React-based interface for generating the Idena whitelist Merkle root and checking an address against it.
+This directory contains a React-based interface for generating the Idena whitelist
+Merkle root and checking an address against it.
 
-At the moment it is a stub with simulated data. Real backend calls and live log streaming will be added later.
+The UI now connects to the Go backend (`http://localhost:3030` by default) and
+streams log output from `/logs/stream` while the whitelist is being built. Make
+sure the main server and rolling indexer are running:
 
-To start developing, install dependencies and use a bundler of your choice (for example `vite`). The entry point is `index.html` which loads `src/index.jsx`.
+```bash
+go run main.go
+# In another terminal
+cd rolling_indexer && go build -o rolling-indexer main.go
+export RPC_URL="http://localhost:9009"
+./rolling-indexer
+```
+
+To develop the frontend, install dependencies and use a bundler of your choice
+(for example `vite`). The entry point is `index.html` which loads
+`src/index.jsx`.


### PR DESCRIPTION
## Summary
- hook Merkle whitelist generator frontend to backend API
- stream logs from `/logs/stream` and show any errors
- document new requirements to run backend and rolling indexer

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68529dc8fce88320b1b9dbeabc8d76de