### PR TITLE
Add balance fetch and combine with identity

### DIFF
--- a/agents/fetch_single_identity.go
+++ b/agents/fetch_single_identity.go
@@ -20,6 +20,22 @@ type IdentityResult struct {
 	Penalty             string   `json:"penalty"`
 }
 
+// BalanceResult holds balance and stake fields from the dna_getBalance RPC response.
+type BalanceResult struct {
+    Stake   string `json:"stake"`
+    Balance string `json:"balance"`
+}
+
+// AccountInfo combines identity and balance info for an address.
+type AccountInfo struct {
+    Address             string
+    State               string
+    Stake               string
+    Balance             string
+    LastValidationFlags []string
+    Penalty             string
+}
+
 // fetchIdentity retrieves identity information for a single address from a local
 // Idena node using the dna_identity RPC method. The API key is optional; if
 // provided it will be included in the request body under the "key" field.
@@ -64,35 +80,90 @@ func fetchIdentity(address, apiKey string) (*IdentityResult, error) {
 	return &out.Result, nil
 }
 
-// fetchIdentities retrieves identity info for multiple addresses concurrently.
-// It spawns a goroutine per address using fetchIdentity and returns a map
-// of address to result. Failed lookups are logged and omitted from the map.
+// fetchBalance retrieves balance information for a single address from the local
+// Idena node using the dna_getBalance RPC method.
+func fetchBalance(address, apiKey string) (*BalanceResult, error) {
+    reqData := map[string]interface{}{
+        "jsonrpc": "2.0",
+        "method":  "dna_getBalance",
+        "params":  []interface{}{address},
+        "id":      2,
+    }
+    if apiKey != "" {
+        reqData["key"] = apiKey
+    }
+
+    body, err := json.Marshal(reqData)
+    if err != nil {
+        return nil, err
+    }
+
+    resp, err := http.Post(localNodeURL, "application/json", bytes.NewReader(body))
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
+    if resp.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("rpc status %s", resp.Status)
+    }
+
+    var out struct {
+        Result BalanceResult `json:"result"`
+        Error  *struct {
+            Code    int    `json:"code"`
+            Message string `json:"message"`
+        } `json:"error"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+        return nil, err
+    }
+    if out.Error != nil {
+        return nil, fmt.Errorf("rpc error %d: %s", out.Error.Code, out.Error.Message)
+    }
+    return &out.Result, nil
+}
+
+// fetchAccountInfos retrieves identity and balance info for multiple addresses concurrently.
+// It spawns a goroutine per address using fetchIdentity and fetchBalance and returns a map
+// of address to combined result. Failed lookups are logged and omitted from the map.
 // Concurrency is limited via a buffered channel acting as a semaphore.
-func fetchIdentities(addresses []string, apiKey string) map[string]IdentityResult {
-	results := make(map[string]IdentityResult)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 5)
+func fetchAccountInfos(addresses []string, apiKey string) map[string]AccountInfo {
+        results := make(map[string]AccountInfo)
+        var mu sync.Mutex
+        var wg sync.WaitGroup
+        sem := make(chan struct{}, 5)
 
-	for _, addr := range addresses {
-		addr := addr
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
+        for _, addr := range addresses {
+                addr := addr
+                wg.Add(1)
+                go func() {
+                        defer wg.Done()
+                        sem <- struct{}{}
+                        defer func() { <-sem }()
 
-			res, err := fetchIdentity(addr, apiKey)
-			if err != nil {
-				log.Printf("[fetchIdentities] %s: %v", addr, err)
-				return
-			}
-			mu.Lock()
-			results[addr] = *res
-			mu.Unlock()
-		}()
-	}
+                        idRes, err := fetchIdentity(addr, apiKey)
+                        if err != nil {
+                                log.Printf("[fetchAccountInfos] identity %s: %v", addr, err)
+                                return
+                        }
+                        balRes, err := fetchBalance(addr, apiKey)
+                        if err != nil {
+                                log.Printf("[fetchAccountInfos] balance %s: %v", addr, err)
+                                return
+                        }
+                        mu.Lock()
+                        results[addr] = AccountInfo{
+                                Address:             idRes.Address,
+                                State:               idRes.State,
+                                Stake:               balRes.Stake,
+                                Balance:             balRes.Balance,
+                                LastValidationFlags: idRes.LastValidationFlags,
+                                Penalty:             idRes.Penalty,
+                        }
+                        mu.Unlock()
+                }()
+        }
 
-	wg.Wait()
-	return results
+        wg.Wait()
+        return results
 }

--- a/agents/fetch_single_identity_test.go
+++ b/agents/fetch_single_identity_test.go
@@ -7,38 +7,52 @@ import (
 	"testing"
 )
 
-func TestFetchIdentities(t *testing.T) {
+func TestFetchAccountInfos(t *testing.T) {
 	ln, err := net.Listen("tcp", "localhost:9009")
 	if err != nil {
 		t.Skipf("listen: %v", err)
 	}
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req struct {
-			Params []string `json:"params"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		resp := map[string]interface{}{
-			"result": map[string]interface{}{
-				"address": req.Params[0],
-				"state":   "Human",
-				"stake":   "0",
-			},
-		}
-		b, _ := json.Marshal(resp)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(b)
-	})}
+        srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                var req struct {
+                        Method string        `json:"method"`
+                        Params []string      `json:"params"`
+                }
+                _ = json.NewDecoder(r.Body).Decode(&req)
+                var resp map[string]interface{}
+                switch req.Method {
+                case "dna_identity":
+                        resp = map[string]interface{}{
+                                "result": map[string]interface{}{
+                                        "address": req.Params[0],
+                                        "state":   "Human",
+                                        "stake":   "0",
+                                        "lastValidationFlags": []string{},
+                                        "penalty": "0",
+                                },
+                        }
+                case "dna_getBalance":
+                        resp = map[string]interface{}{
+                                "result": map[string]interface{}{
+                                        "stake":   "1",
+                                        "balance": "2",
+                                },
+                        }
+                }
+                b, _ := json.Marshal(resp)
+                w.Header().Set("Content-Type", "application/json")
+                w.Write(b)
+        })}
 	go srv.Serve(ln)
 	defer srv.Close()
 
 	addrs := []string{"0x1", "0x2"}
-	res := fetchIdentities(addrs, "")
-	if len(res) != 2 {
-		t.Fatalf("expected 2 results, got %d", len(res))
-	}
-	for _, a := range addrs {
-		if r, ok := res[a]; !ok || r.Address != a {
-			t.Errorf("missing result for %s", a)
-		}
-	}
+        res := fetchAccountInfos(addrs, "")
+        if len(res) != 2 {
+                t.Fatalf("expected 2 results, got %d", len(res))
+        }
+        for _, a := range addrs {
+                if r, ok := res[a]; !ok || r.Address != a || r.Balance != "2" {
+                        t.Errorf("missing result for %s", a)
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- fetch balances via `dna_getBalance` RPC call
- combine identity and balance results into `AccountInfo`
- adjust tests for new function

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d122ebb6c8320b7755c0b3e4aebb4