### PR TITLE
Add whitelist filtering tool

### DIFF
--- a/agents/fetch_single_identity.go
+++ b/agents/fetch_single_identity.go
@@ -164,6 +164,11 @@ func fetchAccountInfos(addresses []string, apiKey string) map[string]AccountInfo
                 }()
         }
 
-        wg.Wait()
-        return results
+       wg.Wait()
+       return results
+}
+
+// FetchAccountInfos exposes fetchAccountInfos for other packages.
+func FetchAccountInfos(addresses []string, apiKey string) map[string]AccountInfo {
+        return fetchAccountInfos(addresses, apiKey)
 }

--- a/cmd/whitelistfilter/main.go
+++ b/cmd/whitelistfilter/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"idenauthgo/agents"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func hasFlag(flags []string, f string) bool {
+	for _, v := range flags {
+		if v == f {
+			return true
+		}
+	}
+	return false
+}
+
+func getThreshold(nodeURL, apiKey string, epoch int) (float64, error) {
+	url := fmt.Sprintf("%s/api/Epoch/%d", strings.TrimRight(nodeURL, "/"), epoch)
+	if apiKey != "" {
+		url += "?apikey=" + apiKey
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Result struct {
+			Threshold string `json:"discriminationStakeThreshold"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return 0, err
+	}
+	return strconv.ParseFloat(out.Result.Threshold, 64)
+}
+
+func main() {
+	input := flag.String("input", "accounts.json", "input JSON file with account info")
+	output := flag.String("output", "whitelist.json", "output whitelist file")
+	nodeURL := flag.String("node", "http://localhost:9009", "Idena node RPC base URL")
+	apiKey := flag.String("key", "", "Idena node API key")
+	jsonl := flag.Bool("jsonl", false, "output JSONL instead of JSON array")
+	flag.Parse()
+
+	data, err := os.ReadFile(*input)
+	if err != nil {
+		log.Fatalf("read input: %v", err)
+	}
+	var infos []agents.AccountInfo
+	if err := json.Unmarshal(data, &infos); err != nil {
+		log.Fatalf("decode input: %v", err)
+	}
+
+	epoch, err := agents.GetCurrentEpoch(*nodeURL, *apiKey)
+	if err != nil {
+		log.Fatalf("get epoch: %v", err)
+	}
+	thr, err := getThreshold(*nodeURL, *apiKey, epoch)
+	if err != nil {
+		log.Fatalf("get threshold: %v", err)
+	}
+
+	var addrs []string
+	for _, info := range infos {
+		stake, _ := strconv.ParseFloat(info.Stake, 64)
+		bal, _ := strconv.ParseFloat(info.Balance, 64)
+		if hasFlag(info.LastValidationFlags, "AllFlipsNotQualified") {
+			continue
+		}
+		if info.State == "Human" && stake < thr {
+			continue
+		}
+		if (info.State == "Newbie" || info.State == "Verified") && stake+bal < 10000 {
+			continue
+		}
+		addrs = append(addrs, strings.ToLower(info.Address))
+	}
+	sort.Strings(addrs)
+
+	var out []byte
+	if *jsonl {
+		out = []byte(strings.Join(addrs, "\n") + "\n")
+	} else {
+		b, _ := json.MarshalIndent(addrs, "", "  ")
+		out = b
+	}
+	if err := os.WriteFile(*output, out, 0644); err != nil {
+		log.Fatalf("write output: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- expose `FetchAccountInfos` for use by other packages
- add `whitelistfilter` command to filter account info and output a whitelist

## Testing
- `go test ./... -count=1 -run '' -timeout=30s`

------
https://chatgpt.com/codex/tasks/task_e_685d13c78fec832085f66f6577db601c