### PR TITLE
Add local short-session whitelist builder

### DIFF
--- a/cmd/autowhitelist/main.go
+++ b/cmd/autowhitelist/main.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"idenauthgo/agents"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultNodeURL   = "http://localhost:9009"
+	addressFile      = "addresses.txt"
+	outFile          = "idena_whitelist.jsonl"
+	thresholdOutFile = "discriminationStakeThreshold.txt"
+	newbieMinStake   = 10000.0
+	verifiedMinStake = 10000.0
+	requiredBlocks   = 7
+)
+
+type epochLastResp struct {
+	Result struct {
+		Epoch     int    `json:"epoch"`
+		Threshold string `json:"discriminationStakeThreshold"`
+	} `json:"result"`
+}
+
+type epochResp struct {
+	Result struct {
+		ValidationFirstBlock int `json:"validationFirstBlockHeight"`
+	} `json:"result"`
+}
+
+type blockFlagsResp struct {
+	Result struct {
+		Flags []string `json:"flags"`
+	} `json:"result"`
+}
+
+type tx struct {
+	From string `json:"from"`
+}
+
+type validationSummary struct {
+	State     string `json:"state"`
+	Stake     string `json:"stake"`
+	Approved  bool   `json:"approved"`
+	Penalized bool   `json:"penalized"`
+}
+
+func apiGet(baseURL, apiKey, path string, out interface{}) error {
+	url := strings.TrimRight(baseURL, "/") + path
+	if apiKey != "" {
+		if strings.Contains(url, "?") {
+			url += "&apikey=" + apiKey
+		} else {
+			url += "?apikey=" + apiKey
+		}
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func getLatestEpochInfo(nodeURL, apiKey string) (int, float64, error) {
+	var res epochLastResp
+	if err := apiGet(nodeURL, apiKey, "/api/Epoch/Last", &res); err != nil {
+		return 0, 0, err
+	}
+	thr, _ := strconv.ParseFloat(res.Result.Threshold, 64)
+	return res.Result.Epoch, thr, nil
+}
+
+func getEpochInfo(nodeURL, apiKey string, epoch int) (int, error) {
+	var res epochResp
+	if err := apiGet(nodeURL, apiKey, fmt.Sprintf("/api/Epoch/%d", epoch), &res); err != nil {
+		return 0, err
+	}
+	return res.Result.ValidationFirstBlock, nil
+}
+
+func getBlockFlags(nodeURL, apiKey string, height int) ([]string, error) {
+	var res blockFlagsResp
+	if err := apiGet(nodeURL, apiKey, fmt.Sprintf("/api/Block/%d", height), &res); err != nil {
+		return nil, err
+	}
+	return res.Result.Flags, nil
+}
+
+func fetchAllTxs(nodeURL, apiKey string, height int) ([]tx, error) {
+	var all []tx
+	cont := ""
+	for {
+		path := fmt.Sprintf("/api/Block/%d/Txs?limit=100", height)
+		if cont != "" {
+			path += "&continuationToken=" + cont
+		}
+		var res struct {
+			Result       []tx   `json:"result"`
+			Continuation string `json:"continuationToken"`
+		}
+		if err := apiGet(nodeURL, apiKey, path, &res); err != nil {
+			return all, err
+		}
+		if res.Result != nil {
+			all = append(all, res.Result...)
+		}
+		if res.Continuation == "" {
+			break
+		}
+		cont = res.Continuation
+		time.Sleep(100 * time.Millisecond)
+	}
+	return all, nil
+}
+
+func findShortSessionBlock(nodeURL, apiKey string, start int) (int, error) {
+	for h := start; h < start+20; h++ {
+		flags, err := getBlockFlags(nodeURL, apiKey, h)
+		if err != nil {
+			continue
+		}
+		for _, f := range flags {
+			if f == "ShortSessionStarted" {
+				return h, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("ShortSessionStarted not found")
+}
+
+func collectAddresses(nodeURL, apiKey string, start int) ([]string, error) {
+	unique := make(map[string]struct{})
+	blocks := 0
+	h := start
+	for blocks < requiredBlocks {
+		txs, err := fetchAllTxs(nodeURL, apiKey, h)
+		if err == nil && len(txs) > 0 {
+			blocks++
+			for _, t := range txs {
+				if t.From != "" {
+					unique[strings.ToLower(t.From)] = struct{}{}
+				}
+			}
+		}
+		h++
+	}
+	list := make([]string, 0, len(unique))
+	for a := range unique {
+		list = append(list, a)
+	}
+	sort.Strings(list)
+	return list, nil
+}
+
+func fetchBadAddresses(nodeURL, apiKey string, epoch int) (map[string]struct{}, error) {
+	bad := make(map[string]struct{})
+	cont := ""
+	for {
+		path := fmt.Sprintf("/api/Epoch/%d/Authors/Bad?limit=100", epoch)
+		if cont != "" {
+			path += "&continuationToken=" + cont
+		}
+		var res struct {
+			Result []struct {
+				Address string `json:"address"`
+			} `json:"result"`
+			Continuation string `json:"continuationToken"`
+		}
+		if err := apiGet(nodeURL, apiKey, path, &res); err != nil {
+			return bad, err
+		}
+		for _, r := range res.Result {
+			bad[strings.ToLower(r.Address)] = struct{}{}
+		}
+		if res.Continuation == "" {
+			break
+		}
+		cont = res.Continuation
+		time.Sleep(100 * time.Millisecond)
+	}
+	return bad, nil
+}
+
+func fetchValidationSummary(nodeURL, apiKey string, epoch int, addr string) (*validationSummary, error) {
+	var out struct {
+		Result validationSummary `json:"result"`
+	}
+	err := apiGet(nodeURL, apiKey, fmt.Sprintf("/api/Epoch/%d/Identity/%s/ValidationSummary", epoch, addr), &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out.Result, nil
+}
+
+func saveLines(path string, lines []string) error {
+	data := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(path, []byte(data), 0644)
+}
+
+func main() {
+	nodeURL := flag.String("node", defaultNodeURL, "Idena node RPC base URL")
+	apiKey := flag.String("key", "", "Idena node API key")
+	auto := flag.Bool("auto-addresses", false, "discover addresses from recent blocks")
+	flag.Parse()
+
+	epoch, threshold, err := getLatestEpochInfo(*nodeURL, *apiKey)
+	if err != nil {
+		log.Fatalf("latest epoch: %v", err)
+	}
+	if err := os.WriteFile(thresholdOutFile, []byte(fmt.Sprintf("%f", threshold)), 0644); err != nil {
+		log.Printf("write threshold: %v", err)
+	}
+
+	var addresses []string
+	if *auto {
+		lastEpoch := epoch - 1
+		firstBlock, err := getEpochInfo(*nodeURL, *apiKey, lastEpoch)
+		if err != nil {
+			log.Fatalf("epoch info: %v", err)
+		}
+		ssStart, err := findShortSessionBlock(*nodeURL, *apiKey, firstBlock+15)
+		if err != nil {
+			log.Fatalf("find short session: %v", err)
+		}
+		addresses, err = collectAddresses(*nodeURL, *apiKey, ssStart)
+		if err != nil {
+			log.Fatalf("collect addresses: %v", err)
+		}
+		if err := saveLines(addressFile, addresses); err != nil {
+			log.Printf("write addresses: %v", err)
+		}
+	} else {
+		addresses, err = agents.LoadAddressList(addressFile)
+		if err != nil {
+			log.Fatalf("load addresses: %v", err)
+		}
+	}
+
+	lastEpoch := epoch - 1
+	bad, err := fetchBadAddresses(*nodeURL, *apiKey, lastEpoch)
+	if err != nil {
+		log.Fatalf("bad authors: %v", err)
+	}
+
+	out, err := os.Create(outFile)
+	if err != nil {
+		log.Fatalf("open output: %v", err)
+	}
+	defer out.Close()
+
+	included := 0
+	for i, addr := range addresses {
+		addrL := strings.ToLower(addr)
+		if _, ok := bad[addrL]; ok {
+			log.Printf("[%d/%d] skip bad author %s", i+1, len(addresses), addr)
+			continue
+		}
+		sum, err := fetchValidationSummary(*nodeURL, *apiKey, lastEpoch, addrL)
+		if err != nil {
+			log.Printf("[%d/%d] summary %s: %v", i+1, len(addresses), addr, err)
+			continue
+		}
+		stake, _ := strconv.ParseFloat(sum.Stake, 64)
+		reason := ""
+		if sum.Penalized || !sum.Approved {
+			reason = "not approved or penalized"
+		} else if sum.State == "Human" {
+			if stake < threshold {
+				reason = fmt.Sprintf("Human stake %.4f below threshold %.4f", stake, threshold)
+			}
+		} else if sum.State == "Newbie" {
+			if stake < newbieMinStake {
+				reason = fmt.Sprintf("Newbie stake %.4f below %.0f", stake, newbieMinStake)
+			}
+		} else if sum.State == "Verified" {
+			if stake < verifiedMinStake {
+				reason = fmt.Sprintf("Verified stake %.4f below %.0f", stake, verifiedMinStake)
+			}
+		} else {
+			reason = "wrong state " + sum.State
+		}
+		if reason != "" {
+			log.Printf("[%d/%d] EXCLUDED %s - %s", i+1, len(addresses), addr, reason)
+			continue
+		}
+		rec := map[string]interface{}{"address": addr, "state": sum.State, "stake": stake}
+		b, _ := json.Marshal(rec)
+		out.Write(b)
+		out.Write([]byte("\n"))
+		included++
+		log.Printf("[%d/%d] OK %s state=%s stake=%.4f", i+1, len(addresses), addr, sum.State, stake)
+		time.Sleep(200 * time.Millisecond)
+	}
+	log.Printf("Done. Whitelisted: %d addresses", included)
+}


### PR DESCRIPTION
## Summary
- implement `autowhitelist` CLI to build a whitelist directly from the local node
- discover short‑session addresses, fetch validation summaries and filter them

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d2866d40883208a5c479e38af8232