### PR TITLE
Refactor eligibility checks

### DIFF
--- a/eligibility/eligibility.go
+++ b/eligibility/eligibility.go
@@ -1,0 +1,23 @@
+package eligibility
+
+// IsEligibleSnapshot checks if a state+stake combination passes the Proof-of-Humanity
+// rules. Humans must meet the dynamic discrimination stake threshold, Verified and
+// Newbie identities need at least 10k iDNA. This helper was duplicated in several
+// packages (server, indexer, strictbuilder). It now lives here for reuse.
+func IsEligibleSnapshot(state string, stake float64, threshold float64) bool {
+	if state == "Human" && stake >= threshold {
+		return true
+	}
+	if (state == "Verified" || state == "Newbie") && stake >= 10000 {
+		return true
+	}
+	return false
+}
+
+// IsEligibleFull applies the snapshot rules plus penalty/flip checks.
+func IsEligibleFull(state string, stake float64, penalized, flip bool, threshold float64) bool {
+	if penalized || flip {
+		return false
+	}
+	return IsEligibleSnapshot(state, stake, threshold)
+}

--- a/fallback_bootstrap.go
+++ b/fallback_bootstrap.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"idenauthgo/eligibility"
 )
 
 // requiredBlocks defines how many consecutive blocks after short session start
@@ -177,7 +179,7 @@ func buildEpochWhitelistAPI(epoch int, threshold float64) error {
 			Penalized:    sum.Penalized,
 			FlipReported: flip,
 		})
-		if !sum.Penalized && !flip && isEligibleSnapshot(sum.State, stake, threshold) {
+		if eligibility.IsEligibleFull(sum.State, stake, sum.Penalized, flip, threshold) {
 			list = append(list, addr)
 		}
 	}

--- a/rolling_indexer/go.mod
+++ b/rolling_indexer/go.mod
@@ -5,3 +5,7 @@ go 1.21
 toolchain go1.22.3
 
 require github.com/mattn/go-sqlite3 v1.14.28
+
+require idenauthgo v0.0.0
+
+replace idenauthgo => ../

--- a/rolling_indexer/main.go
+++ b/rolling_indexer/main.go
@@ -36,6 +36,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"idenauthgo/eligibility"
 )
 
 // Config holds runtime settings loaded from env or config.json
@@ -424,16 +426,6 @@ func handleLatest(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(list)
 }
 
-func isEligibleSnapshot(state string, stake float64, threshold float64) bool {
-	if state == "Human" && stake >= threshold {
-		return true
-	}
-	if (state == "Verified" || state == "Newbie") && stake >= 10000 {
-		return true
-	}
-	return false
-}
-
 func queryEligibleSnapshots() ([]Snapshot, error) {
 	_, thr, err := getEpochAndThreshold()
 	if err != nil || thr == 0 {
@@ -460,7 +452,7 @@ func queryEligibleSnapshots() ([]Snapshot, error) {
 	// filter by eligibility rules using the latest threshold
 	var list []Snapshot
 	for _, s := range all {
-		if isEligibleSnapshot(s.State, s.Stake, thr) {
+		if eligibility.IsEligibleSnapshot(s.State, s.Stake, thr) {
 			list = append(list, s)
 		}
 	}


### PR DESCRIPTION
## Summary
- centralize PoH eligibility rules in new `eligibility` package
- reuse centralized check from main server, indexer and CLI tools
- remove local duplicates and update imports

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d524ba2588320b4351ee28bc1ed08