### PR TITLE
Fix bootstrap RPC endpoint

### DIFF
--- a/rolling_indexer/main.go
+++ b/rolling_indexer/main.go
@@ -207,7 +207,9 @@ func fetchPublicEpochIdentities(epoch int) ([]Snapshot, error) {
 		"id":      1,
 	}
 	body, _ := json.Marshal(req)
-	resp, err := http.Post("https://rpc.idena.io", "application/json", bytes.NewReader(body))
+	// Use the public REST API endpoint instead of the old rpc.idena.io
+	// endpoint (which now serves a web app and returns HTML).
+	resp, err := http.Post("https://api.idena.io", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- update rolling indexer bootstrap RPC calls to use `https://api.idena.io`
- clarify comment about deprecated `rpc.idena.io` endpoint

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685dba8182b483209bd61a9e7ca55818