### PR TITLE
Fix epoch threshold type

### DIFF
--- a/agents/identity_fetcher.go
+++ b/agents/identity_fetcher.go
@@ -162,15 +162,14 @@ func getEpochLast(nodeURL, apiKey string) (int, float64, error) {
 	defer resp.Body.Close()
 	var out struct {
 		Result struct {
-			Epoch     int    `json:"epoch"`
-			Threshold string `json:"discriminationStakeThreshold"`
+			Epoch     int     `json:"epoch"`
+			Threshold float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return 0, 0, err
 	}
-	thr, _ := strconv.ParseFloat(out.Result.Threshold, 64)
-	return out.Result.Epoch, thr, nil
+	return out.Result.Epoch, out.Result.Threshold, nil
 }
 
 // fetchBadAuthors returns a set of bad authors for the given epoch.

--- a/cmd/autowhitelist/main.go
+++ b/cmd/autowhitelist/main.go
@@ -29,8 +29,8 @@ const (
 
 type epochLastResp struct {
 	Result struct {
-		Epoch     int    `json:"epoch"`
-		Threshold string `json:"discriminationStakeThreshold"`
+		Epoch     int     `json:"epoch"`
+		Threshold float64 `json:"discriminationStakeThreshold"`
 	} `json:"result"`
 }
 
@@ -82,8 +82,7 @@ func getLatestEpochInfo(nodeURL, apiKey string) (int, float64, error) {
 	if err := apiGet(nodeURL, apiKey, "/api/Epoch/Last", &res); err != nil {
 		return 0, 0, err
 	}
-	thr, _ := strconv.ParseFloat(res.Result.Threshold, 64)
-	return res.Result.Epoch, thr, nil
+	return res.Result.Epoch, res.Result.Threshold, nil
 }
 
 func getEpochInfo(nodeURL, apiKey string, epoch int) (int, error) {

--- a/cmd/strictbuilder/main.go
+++ b/cmd/strictbuilder/main.go
@@ -23,9 +23,9 @@ const (
 )
 
 type epochInfo struct {
-	Epoch                int    `json:"epoch"`
-	Threshold            string `json:"discriminationStakeThreshold"`
-	ValidationFirstBlock int    `json:"validationFirstBlockHeight"`
+	Epoch                int     `json:"epoch"`
+	Threshold            float64 `json:"discriminationStakeThreshold"`
+	ValidationFirstBlock int     `json:"validationFirstBlockHeight"`
 }
 
 type blockResp struct {
@@ -60,15 +60,14 @@ func getJSON(url string, out interface{}) error {
 func getLatestEpochInfo() (int, float64, error) {
 	var data struct {
 		Result struct {
-			Epoch     int    `json:"epoch"`
-			Threshold string `json:"discriminationStakeThreshold"`
+			Epoch     int     `json:"epoch"`
+			Threshold float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 	}
 	if err := getJSON("https://api.idena.io/api/Epoch/Last", &data); err != nil {
 		return 0, 0, err
 	}
-	thr, _ := strconv.ParseFloat(data.Result.Threshold, 64)
-	return data.Result.Epoch, thr, nil
+	return data.Result.Epoch, data.Result.Threshold, nil
 }
 
 func getEpochInfo(epoch int) (int, error) {

--- a/cmd/whitelistfilter/main.go
+++ b/cmd/whitelistfilter/main.go
@@ -34,13 +34,13 @@ func getThreshold(nodeURL, apiKey string, epoch int) (float64, error) {
 	defer resp.Body.Close()
 	var out struct {
 		Result struct {
-			Threshold string `json:"discriminationStakeThreshold"`
+			Threshold float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return 0, err
 	}
-	return strconv.ParseFloat(out.Result.Threshold, 64)
+	return out.Result.Threshold, nil
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -130,15 +130,14 @@ func fetchEpochData() (int, float64, error) {
 	defer resp.Body.Close()
 	var result struct {
 		Result struct {
-			Epoch     int    `json:"epoch"`
-			Threshold string `json:"discriminationStakeThreshold"`
+			Epoch     int     `json:"epoch"`
+			Threshold float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return 0, 0, err
 	}
-	thr, _ := strconv.ParseFloat(result.Result.Threshold, 64)
-	return result.Result.Epoch, thr, nil
+	return result.Result.Epoch, result.Result.Threshold, nil
 }
 
 func main() {
@@ -1514,9 +1513,9 @@ func saveEpoch(epoch int, vt int64, thr float64) {
 func fetchEpochFromNode() (int, int64, float64, error) {
 	var resp struct {
 		Result struct {
-			Epoch          int    `json:"epoch"`
-			ValidationTime string `json:"validationTime"`
-			Threshold      string `json:"discriminationStakeThreshold"`
+			Epoch          int     `json:"epoch"`
+			ValidationTime string  `json:"validationTime"`
+			Threshold      float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 		Error *struct {
 			Code    int    `json:"code"`
@@ -1530,8 +1529,7 @@ func fetchEpochFromNode() (int, int64, float64, error) {
 		return 0, 0, 0, fmt.Errorf(resp.Error.Message)
 	}
 	vt, _ := time.Parse(time.RFC3339, resp.Result.ValidationTime)
-	thr, _ := strconv.ParseFloat(resp.Result.Threshold, 64)
-	return resp.Result.Epoch, vt.Unix(), thr, nil
+	return resp.Result.Epoch, vt.Unix(), resp.Result.Threshold, nil
 }
 
 // fetchEpochFromAPI gets epoch info from the public API.
@@ -1546,17 +1544,16 @@ func fetchEpochFromAPI() (int, int64, float64, error) {
 	}
 	var apiResp struct {
 		Result struct {
-			Epoch          int    `json:"epoch"`
-			ValidationTime string `json:"validationTime"`
-			Threshold      string `json:"discriminationStakeThreshold"`
+			Epoch          int     `json:"epoch"`
+			ValidationTime string  `json:"validationTime"`
+			Threshold      float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return 0, 0, 0, err
 	}
 	vt, _ := time.Parse(time.RFC3339, apiResp.Result.ValidationTime)
-	thr, _ := strconv.ParseFloat(apiResp.Result.Threshold, 64)
-	return apiResp.Result.Epoch, vt.Unix(), thr, nil
+	return apiResp.Result.Epoch, vt.Unix(), apiResp.Result.Threshold, nil
 }
 
 // updateEpochCache tries to refresh epoch info from the node, falling back to the public API.

--- a/rolling_indexer/main.go
+++ b/rolling_indexer/main.go
@@ -616,8 +616,8 @@ func handleState(w http.ResponseWriter, r *http.Request) {
 func getEpochAndThreshold() (int, float64, error) {
 	var out struct {
 		Result struct {
-			Epoch     int    `json:"epoch"`
-			Threshold string `json:"discriminationStakeThreshold"`
+			Epoch     int     `json:"epoch"`
+			Threshold float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 		Error *struct {
 			Message string `json:"message"`
@@ -629,8 +629,7 @@ func getEpochAndThreshold() (int, float64, error) {
 	if out.Error != nil && out.Error.Message != "" {
 		return 0, 0, errors.New(out.Error.Message)
 	}
-	thr, _ := strconv.ParseFloat(out.Result.Threshold, 64)
-	return out.Result.Epoch, thr, nil
+	return out.Result.Epoch, out.Result.Threshold, nil
 }
 
 // getEpochAndThresholdFor returns epoch data for the given epoch using JSON-RPC.
@@ -638,8 +637,8 @@ func getEpochAndThreshold() (int, float64, error) {
 func getEpochAndThresholdFor(ep int) (int, float64, error) {
 	var out struct {
 		Result struct {
-			Epoch     int    `json:"epoch"`
-			Threshold string `json:"discriminationStakeThreshold"`
+			Epoch     int     `json:"epoch"`
+			Threshold float64 `json:"discriminationStakeThreshold"`
 		} `json:"result"`
 		Error *struct {
 			Message string `json:"message"`
@@ -654,8 +653,7 @@ func getEpochAndThresholdFor(ep int) (int, float64, error) {
 	if out.Error != nil && out.Error.Message != "" {
 		return 0, 0, errors.New(out.Error.Message)
 	}
-	thr, _ := strconv.ParseFloat(out.Result.Threshold, 64)
-	return out.Result.Epoch, thr, nil
+	return out.Result.Epoch, out.Result.Threshold, nil
 }
 
 // handleEpochLast serves the /api/Epoch/Last endpoint.


### PR DESCRIPTION
## Summary
- parse epoch threshold from JSON as float64
- update struct fields for discrimination stake threshold

## Testing
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e8d2fddc08320bc8d6a0b0318d522