### PR TITLE
Add static server docs and improve strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Set the necessary values in .env (or as actual environment variables):
 ```
 BASE_URL – the base URL for your running backend (e.g. http://localhost:3030)
 
-IDENA_RPC_KEY – (optional) your Idena node’s API key, if your node requires one for RPC calls
+IDENA_RPC_KEY – (optional) your Idena node’s API key, if your node requires one for RPC calls. Never hardcode or log this value.
 ```
 
 For example, on a Unix-like system you can export them directly:

--- a/cmd/strictserver/README.md
+++ b/cmd/strictserver/README.md
@@ -1,0 +1,28 @@
+# Strict Whitelist Server
+
+This lightweight server exposes endpoints for building a strict whitelist directly from a local Idena node. It serves a static web page from `static/` at the root path.
+
+## Usage
+
+Set the environment variable `IDENA_RPC_KEY` if your node RPC is protected by an API key. The value must **not** be hardcoded in your code or logs. Start the server:
+
+```bash
+go run ./cmd/strictserver
+```
+
+### Endpoints
+
+- `/snapshot` &mdash; build a new whitelist by fetching identities from the node
+- `/whitelist/current` &mdash; serve the most recently generated whitelist
+- `/whitelist/epoch/{n}` &mdash; serve the whitelist for epoch `n`
+- `/whitelist/check?address=ADDR` &mdash; return eligibility info for `ADDR`
+- `/whitelist/download` &mdash; download the latest whitelist as `whitelist.jsonl`
+
+See the example commands in `static/index.html` for quick testing.
+
+You can replace `static/index.html` with your own file to customize the landing page.
+
+### Requirements
+
+- A running Idena node with RPC enabled (default `http://localhost:9009`).
+- `IDENA_RPC_KEY` exported if the node requires an API key.

--- a/cmd/strictserver/main.go
+++ b/cmd/strictserver/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"idenauthgo/strictlocal"
+)
+
+var (
+	nodeURL = "http://localhost:9009"
+	// IDENA_RPC_KEY must be set in the environment if the node requires it.
+	// Never hardcode or log this value.
+	apiKey      = os.Getenv("IDENA_RPC_KEY")
+	dbPath      = ""
+	currentFile = ""
+)
+
+func runSnapshot(w http.ResponseWriter, r *http.Request) {
+	log.Println("/snapshot requested")
+	if err := strictlocal.BuildWhitelist(nodeURL, apiKey, dbPath); err != nil {
+		log.Printf("snapshot error: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	currentFile = latestFile()
+	w.Write([]byte("ok"))
+}
+
+func latestFile() string {
+	files, _ := filepath.Glob("data/whitelist_epoch_*.jsonl")
+	if len(files) == 0 {
+		return ""
+	}
+	latest := files[len(files)-1]
+	log.Printf("using whitelist file %s", latest)
+	return latest
+}
+
+func serveCurrent(w http.ResponseWriter, r *http.Request) {
+	if currentFile == "" {
+		currentFile = latestFile()
+	}
+	if currentFile == "" {
+		http.Error(w, "no whitelist", 404)
+		return
+	}
+	log.Printf("serving current whitelist %s", currentFile)
+	http.ServeFile(w, r, currentFile)
+}
+
+func serveEpoch(w http.ResponseWriter, r *http.Request) {
+	ep := filepath.Base(r.URL.Path)
+	file := filepath.Join("data", "whitelist_epoch_"+ep+".jsonl")
+	log.Printf("serving epoch whitelist %s", file)
+	http.ServeFile(w, r, file)
+}
+
+func checkAddr(w http.ResponseWriter, r *http.Request) {
+	addr := r.URL.Query().Get("address")
+	if addr == "" {
+		http.Error(w, "missing address", 400)
+		return
+	}
+	if currentFile == "" {
+		currentFile = latestFile()
+	}
+	f, err := os.Open(currentFile)
+	if err != nil {
+		log.Printf("open whitelist error: %v", err)
+		http.Error(w, "no whitelist", http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	for {
+		var rec strictlocal.IdentityInfo
+		if err := dec.Decode(&rec); err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Printf("decode error: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if strings.EqualFold(rec.Address, addr) {
+			json.NewEncoder(w).Encode(rec)
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func download(w http.ResponseWriter, r *http.Request) {
+	if currentFile == "" {
+		currentFile = latestFile()
+	}
+	if currentFile == "" {
+		http.Error(w, "no whitelist", 404)
+		return
+	}
+	w.Header().Set("Content-Disposition", "attachment; filename=whitelist.jsonl")
+	log.Printf("download %s", currentFile)
+	http.ServeFile(w, r, currentFile)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/snapshot", runSnapshot)
+	mux.HandleFunc("/whitelist/current", serveCurrent)
+	mux.HandleFunc("/whitelist/epoch/", serveEpoch)
+	mux.HandleFunc("/whitelist/check", checkAddr)
+	mux.HandleFunc("/whitelist/download", download)
+	mux.Handle("/", http.FileServer(http.Dir("static")))
+	log.Println("strictserver listening on :8081")
+	log.Fatal(http.ListenAndServe(":8081", mux))
+}

--- a/static/eligibility.html
+++ b/static/eligibility.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Eligibility Checker | proof of human</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <style>
+    body {
+      background: #16181c;
+      color: #f5f7fa;
+      margin: 0;
+      padding: 0;
+      font-family: system-ui, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .container {
+      width: 100%;
+      max-width: 420px;
+      margin: 28px auto 0 auto;
+      padding: 0 8px;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      gap: 26px;
+    }
+    .card {
+      background: #20232a;
+      border-radius: 14px;
+      box-shadow: 0 4px 24px #2360ff12;
+      padding: 24px 18px 18px 18px;
+      text-align: center;
+    }
+    .card h1, .card h2 {
+      margin-top: 0;
+      margin-bottom: 12px;
+      color: #62a6ff;
+      font-size: 1.3em;
+    }
+    .card p {
+      margin: 8px 0 0 0;
+      color: #ccd6e0;
+      font-size: 1em;
+    }
+    .btn-primary {
+      display: block;
+      width: 100%;
+      margin: 14px 0;
+      background: linear-gradient(90deg, #2261a6 60%, #348ffe 100%);
+      color: #fff;
+      padding: 18px 0;
+      border: none;
+      border-radius: 8px;
+      font-size: 1.2em;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 8px #2261a644;
+      transition: background 0.2s;
+    }
+    .btn-primary:hover {
+      background: linear-gradient(90deg, #348ffe 30%, #2261a6 100%);
+    }
+    .signin-link {
+      display: block;
+      width: 100%;
+      margin: 8px 0;
+      background: #ccc;
+      color: #666;
+      padding: 10px 0;
+      border-radius: 8px;
+      font-size: 0.95em;
+      text-decoration: none;
+    }
+    .signin-link:hover {
+      background: #aaa;
+      color: #333;
+    }
+    .rules {
+      list-style: disc;
+      text-align: left;
+      margin: 8px 0 0 18px;
+      color: #9eb2c5;
+      font-size: 0.99em;
+    }
+    .rules li {
+      margin-bottom: 6px;
+    }
+      color: #89bbfd;
+      font-weight: 600;
+      display: block;
+      font-size: 1.08em;
+      margin: 16px 0 4px 0;
+      text-decoration: underline dotted;
+      word-break: break-all;
+    }
+    .disclaimer {
+      background: #24272e;
+      color: #a9bacd;
+      border-radius: 10px;
+      font-size: 0.97em;
+      padding: 17px 13px 13px 13px;
+      margin-bottom: 12px;
+      text-align: left;
+      box-shadow: 0 2px 8px #33446633;
+    }
+    @media (max-width: 500px) {
+      .container { max-width: 98vw; }
+      .card, .disclaimer { padding: 16px 7px 11px 7px; }
+      .btn-primary { font-size: 1em; }
+      .github-link { font-size: 1em; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <h1>Eligibility Checker</h1>
+      <p>Check an address or sign in with Idena.</p>
+      <input id="addr" type="text" placeholder="0x..." style="width:100%;padding:12px;border-radius:8px;border:1px solid #555;background:#2b2e34;color:#fff;" />
+      <button class="btn-primary" onclick="checkAddr()">Check address</button>
+      <div id="result" style="white-space:pre-wrap;margin:8px 0 0 0;"></div>
+      <a href="/signin" class="signin-link">Sign in with Idena</a>
+      <ul class="rules">
+        <li>Must be <strong>Human</strong>, <strong>Verified</strong>, or <strong>Newbie</strong></li>
+        <li>Human: must meet the current threshold (<strong id="human-threshold">...</strong> IDNA)</li>
+        <li>Verified/Newbie: must have 10,000+ IDNA at stake</li>
+        <li>Must NOT be excluded for flip reporting or penalties ("shitflipper" exclusion)</li>
+      </ul>
+    </div>
+    <a class="github-link" href="https://github.com/ubiubi18/IdenaAuthGo" target="_blank" rel="noopener">Source on GitHub</a>
+    <div class="disclaimer">
+      <b>Disclaimer:</b> This is a hobby, non-commercial, experimental project. No guarantee of accuracy, completeness, security, or availability. Use at your own risk. Source on GitHub.
+    </div>
+  </div>
+</body>
+<script>
+function checkAddr() {
+  const a = document.getElementById('addr').value.trim();
+  const result = document.getElementById('result');
+  if(!a) { result.textContent = 'Enter an address'; return; }
+  result.textContent = 'Checking...';
+  fetch('/eligibility?address='+a)
+    .then(r=>r.json())
+    .then(res=>{
+      const lines = [];
+      lines.push(`Eligibility as of epoch ${res.epoch}, block ${res.block}:`);
+      lines.push(res.eligible ? '<span style="color:#7bf27b">✅ Eligible</span>' : '<span style="color:#ff6b6b">❌ Not eligible</span>');
+      if(res.state) lines.push('Identity: '+res.state);
+      if(typeof res.stake === 'number') lines.push('Stake: '+res.stake.toLocaleString('en-US')+' IDNA');
+      if(res.reason) lines.push('Reason: '+res.reason);
+      if(res.prediction){
+        const warn = res.prediction.includes('not next');
+        let line = 'Next epoch prediction: '+res.prediction;
+        if(warn) line = '<span style="color:#ffd860">'+line+'</span>';
+        lines.push(warn? '⚠️ '+line : line);
+      }
+      result.innerHTML = lines.join('<br>');
+    })
+    .catch(()=>{ result.textContent = 'Error checking address'; });
+}
+fetch('/api/Epoch/Last').then(r=>r.json()).then(d=>{
+  const thr = parseFloat(d.result.discriminationStakeThreshold);
+  document.getElementById('human-threshold').textContent = Math.round(thr).toLocaleString();
+});
+</script>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -1,168 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Eligibility Checker | proof of human</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <style>
-    body {
-      background: #16181c;
-      color: #f5f7fa;
-      margin: 0;
-      padding: 0;
-      font-family: system-ui, sans-serif;
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-    .container {
-      width: 100%;
-      max-width: 420px;
-      margin: 28px auto 0 auto;
-      padding: 0 8px;
-      box-sizing: border-box;
-      display: flex;
-      flex-direction: column;
-      gap: 26px;
-    }
-    .card {
-      background: #20232a;
-      border-radius: 14px;
-      box-shadow: 0 4px 24px #2360ff12;
-      padding: 24px 18px 18px 18px;
-      text-align: center;
-    }
-    .card h1, .card h2 {
-      margin-top: 0;
-      margin-bottom: 12px;
-      color: #62a6ff;
-      font-size: 1.3em;
-    }
-    .card p {
-      margin: 8px 0 0 0;
-      color: #ccd6e0;
-      font-size: 1em;
-    }
-    .btn-primary {
-      display: block;
-      width: 100%;
-      margin: 14px 0;
-      background: linear-gradient(90deg, #2261a6 60%, #348ffe 100%);
-      color: #fff;
-      padding: 18px 0;
-      border: none;
-      border-radius: 8px;
-      font-size: 1.2em;
-      font-weight: 600;
-      cursor: pointer;
-      box-shadow: 0 2px 8px #2261a644;
-      transition: background 0.2s;
-    }
-    .btn-primary:hover {
-      background: linear-gradient(90deg, #348ffe 30%, #2261a6 100%);
-    }
-    .signin-link {
-      display: block;
-      width: 100%;
-      margin: 8px 0;
-      background: #ccc;
-      color: #666;
-      padding: 10px 0;
-      border-radius: 8px;
-      font-size: 0.95em;
-      text-decoration: none;
-    }
-    .signin-link:hover {
-      background: #aaa;
-      color: #333;
-    }
-    .rules {
-      list-style: disc;
-      text-align: left;
-      margin: 8px 0 0 18px;
-      color: #9eb2c5;
-      font-size: 0.99em;
-    }
-    .rules li {
-      margin-bottom: 6px;
-    }
-      color: #89bbfd;
-      font-weight: 600;
-      display: block;
-      font-size: 1.08em;
-      margin: 16px 0 4px 0;
-      text-decoration: underline dotted;
-      word-break: break-all;
-    }
-    .disclaimer {
-      background: #24272e;
-      color: #a9bacd;
-      border-radius: 10px;
-      font-size: 0.97em;
-      padding: 17px 13px 13px 13px;
-      margin-bottom: 12px;
-      text-align: left;
-      box-shadow: 0 2px 8px #33446633;
-    }
-    @media (max-width: 500px) {
-      .container { max-width: 98vw; }
-      .card, .disclaimer { padding: 16px 7px 11px 7px; }
-      .btn-primary { font-size: 1em; }
-      .github-link { font-size: 1em; }
-    }
-  </style>
+<meta charset="UTF-8">
+<title>Idena Whitelist API</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body{font-family:Arial,Helvetica,sans-serif;margin:2rem;background:#f4f4f4;color:#333;}
+pre{background:#eee;padding:1rem;border-radius:8px;overflow:auto;}
+</style>
 </head>
 <body>
-  <div class="container">
-    <div class="card">
-      <h1>Eligibility Checker</h1>
-      <p>Check an address or sign in with Idena.</p>
-      <input id="addr" type="text" placeholder="0x..." style="width:100%;padding:12px;border-radius:8px;border:1px solid #555;background:#2b2e34;color:#fff;" />
-      <button class="btn-primary" onclick="checkAddr()">Check address</button>
-      <div id="result" style="white-space:pre-wrap;margin:8px 0 0 0;"></div>
-      <a href="/signin" class="signin-link">Sign in with Idena</a>
-      <ul class="rules">
-        <li>Must be <strong>Human</strong>, <strong>Verified</strong>, or <strong>Newbie</strong></li>
-        <li>Human: must meet the current threshold (<strong id="human-threshold">...</strong> IDNA)</li>
-        <li>Verified/Newbie: must have 10,000+ IDNA at stake</li>
-        <li>Must NOT be excluded for flip reporting or penalties ("shitflipper" exclusion)</li>
-      </ul>
-    </div>
-    <a class="github-link" href="https://github.com/ubiubi18/IdenaAuthGo" target="_blank" rel="noopener">Source on GitHub</a>
-    <div class="disclaimer">
-      <b>Disclaimer:</b> This is a hobby, non-commercial, experimental project. No guarantee of accuracy, completeness, security, or availability. Use at your own risk. Source on GitHub.
-    </div>
-  </div>
+<h1>Idena Whitelist API</h1>
+<p>This server provides endpoints to build and download strict whitelists from your local Idena node.</p>
+<h2>Example usage</h2>
+<pre>
+# trigger a new snapshot
+curl http://localhost:8081/snapshot
+
+# download the latest whitelist
+curl -L http://localhost:8081/whitelist/download -o whitelist.jsonl
+
+# check a single address
+curl "http://localhost:8081/whitelist/check?address=0x..."
+</pre>
+<p>The <code>IDENA_RPC_KEY</code> environment variable must be set if your node requires an API key.</p>
+<p>You can replace this page by placing your own <code>index.html</code> in the <code>static/</code> directory.</p>
 </body>
-<script>
-function checkAddr() {
-  const a = document.getElementById('addr').value.trim();
-  const result = document.getElementById('result');
-  if(!a) { result.textContent = 'Enter an address'; return; }
-  result.textContent = 'Checking...';
-  fetch('/eligibility?address='+a)
-    .then(r=>r.json())
-    .then(res=>{
-      const lines = [];
-      lines.push(`Eligibility as of epoch ${res.epoch}, block ${res.block}:`);
-      lines.push(res.eligible ? '<span style="color:#7bf27b">✅ Eligible</span>' : '<span style="color:#ff6b6b">❌ Not eligible</span>');
-      if(res.state) lines.push('Identity: '+res.state);
-      if(typeof res.stake === 'number') lines.push('Stake: '+res.stake.toLocaleString('en-US')+' IDNA');
-      if(res.reason) lines.push('Reason: '+res.reason);
-      if(res.prediction){
-        const warn = res.prediction.includes('not next');
-        let line = 'Next epoch prediction: '+res.prediction;
-        if(warn) line = '<span style="color:#ffd860">'+line+'</span>';
-        lines.push(warn? '⚠️ '+line : line);
-      }
-      result.innerHTML = lines.join('<br>');
-    })
-    .catch(()=>{ result.textContent = 'Error checking address'; });
-}
-fetch('/api/Epoch/Last').then(r=>r.json()).then(d=>{
-  const thr = parseFloat(d.result.discriminationStakeThreshold);
-  document.getElementById('human-threshold').textContent = Math.round(thr).toLocaleString();
-});
-</script>
 </html>

--- a/strictlocal/builder.go
+++ b/strictlocal/builder.go
@@ -1,0 +1,229 @@
+package strictlocal
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	_ "github.com/mattn/go-sqlite3"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// IdentityInfo holds minimal identity data for whitelist filtering
+// Penalty comes as string in RPC response but is compared as is.
+// lastValidationFlags may be nil.
+type IdentityInfo struct {
+	Address string   `json:"address"`
+	Stake   float64  `json:"stake"`
+	State   string   `json:"state"`
+	Penalty string   `json:"penalty"`
+	Flags   []string `json:"lastValidationFlags"`
+}
+
+// rpcCall performs a JSON-RPC request against the node.
+// Example curl equivalent:
+//
+//	curl -X POST http://localhost:9009 -H 'Content-Type: application/json' \
+//	  -d '{"method":"<method>","params":[],"id":1,"key":"$IDENA_RPC_KEY"}'
+func rpcCall(nodeURL, apiKey, method string, params []interface{}, out interface{}) error {
+	req := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+		"id":      1,
+	}
+	if apiKey != "" {
+		req["key"] = apiKey
+	}
+	body, _ := json.Marshal(req)
+	resp, err := http.Post(nodeURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("rpc status %s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// filterIdentities applies the strict eligibility rules.
+// It mirrors the logic of build_idena_identities_strict.py.
+func filterIdentities(list []IdentityInfo, threshold float64) []IdentityInfo {
+	var eligible []IdentityInfo
+	for _, info := range list {
+		if info.Penalty != "0" {
+			continue
+		}
+		flagBad := false
+		for _, f := range info.Flags {
+			if f == "AtLeastOneFlipReported" {
+				flagBad = true
+				break
+			}
+		}
+		if flagBad {
+			continue
+		}
+		switch info.State {
+		case "Human":
+			if info.Stake >= threshold {
+				eligible = append(eligible, info)
+			}
+		case "Newbie", "Verified":
+			if info.Stake >= 10000 {
+				eligible = append(eligible, info)
+			}
+		case "Undefined":
+			// explicitly excluded
+			continue
+		}
+	}
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].Address < eligible[j].Address })
+	return eligible
+}
+
+// BuildWhitelist fetches identity data for the given epoch and writes a JSONL whitelist.
+// If dbPath is non-empty, identities are loaded from the indexer database using
+// `SELECT address, state, stake FROM identity WHERE block_height = {startBlock}`.
+// Otherwise dna_identities is used as fallback.
+// BuildWhitelist fetches identities from the local node or an indexer snapshot
+// and writes a strict whitelist to data/whitelist_epoch_<epoch>.jsonl.
+// SQL reference if dbPath is provided:
+//
+//	SELECT address, state, stake FROM identity WHERE block_height = {startBlock};
+func BuildWhitelist(nodeURL, apiKey, dbPath string) error {
+	log.Println("starting snapshot build")
+	var epochInfo struct {
+		Result struct {
+			StartBlock int `json:"startBlock"`
+			Epoch      int `json:"epoch"`
+		} `json:"result"`
+	}
+	if err := rpcCall(nodeURL, apiKey, "dna_epoch", nil, &epochInfo); err != nil {
+		log.Printf("rpc dna_epoch error: %v", err)
+		return err
+	}
+	startBlock := epochInfo.Result.StartBlock
+
+	// Step: obtain address snapshot
+	type basic struct {
+		Address string `json:"address"`
+		State   string `json:"state"`
+		Stake   string `json:"stake"`
+	}
+	var basics []basic
+	if dbPath != "" {
+		log.Printf("loading snapshot from %s", dbPath)
+		db, err := sql.Open("sqlite3", dbPath)
+		if err == nil {
+			rows, err2 := db.Query(`SELECT address, state, stake FROM identity WHERE block_height = ?`, startBlock)
+			if err2 == nil {
+				for rows.Next() {
+					var addr, state string
+					var stake float64
+					if err := rows.Scan(&addr, &state, &stake); err == nil {
+						basics = append(basics, basic{Address: addr, State: state, Stake: fmt.Sprintf("%f", stake)})
+					}
+				}
+				rows.Close()
+				db.Close()
+			} else {
+				log.Printf("sql query error: %v", err2)
+			}
+		} else {
+			log.Printf("open db error: %v", err)
+		}
+	}
+	if len(basics) == 0 {
+		// fallback to live node
+		var resp struct {
+			Result []basic `json:"result"`
+		}
+		if err := rpcCall(nodeURL, apiKey, "dna_identities", nil, &resp); err != nil {
+			log.Printf("rpc dna_identities error: %v", err)
+			return err
+		}
+		basics = resp.Result
+	}
+
+	// Step: fetch global state for threshold
+	var gs struct {
+		Result struct {
+			Threshold float64 `json:"discriminationStakeThreshold,string"`
+		} `json:"result"`
+	}
+	if err := rpcCall(nodeURL, apiKey, "dna_globalState", nil, &gs); err != nil {
+		log.Printf("rpc dna_globalState error: %v", err)
+		return err
+	}
+	threshold := gs.Result.Threshold
+	os.WriteFile("data/discriminationStakeThreshold.txt", []byte(fmt.Sprintf("%.8f", threshold)), 0644)
+
+	// Step: fetch full identity info
+	var list []IdentityInfo
+	var mu sync.Mutex
+	sem := make(chan struct{}, 5) // TODO: make concurrency configurable
+	var wg sync.WaitGroup
+	for _, b := range basics {
+		addr := b.Address
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			var id struct {
+				Result struct {
+					Address string   `json:"address"`
+					Stake   string   `json:"stake"`
+					State   string   `json:"state"`
+					Penalty string   `json:"penalty"`
+					Flags   []string `json:"lastValidationFlags"`
+				} `json:"result"`
+			}
+			if err := rpcCall(nodeURL, apiKey, "dna_identity", []interface{}{addr}, &id); err != nil {
+				log.Printf("rpc dna_identity %s: %v", addr, err)
+				return
+			}
+			stake, _ := strconv.ParseFloat(id.Result.Stake, 64)
+			info := IdentityInfo{
+				Address: strings.ToLower(id.Result.Address),
+				Stake:   stake,
+				State:   id.Result.State,
+				Penalty: id.Result.Penalty,
+				Flags:   id.Result.Flags,
+			}
+			mu.Lock()
+			list = append(list, info)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Step: filtering
+	eligible := filterIdentities(list, threshold)
+
+	// Step: write JSONL
+	outPath := fmt.Sprintf("data/whitelist_epoch_%d.jsonl", epochInfo.Result.Epoch)
+	log.Printf("writing whitelist %s for epoch %d", outPath, epochInfo.Result.Epoch)
+	f, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, e := range eligible {
+		if err := enc.Encode(e); err != nil {
+			return err
+		}
+	}
+	log.Printf("snapshot complete: %d eligible identities", len(eligible))
+	return nil
+}

--- a/strictlocal/builder_test.go
+++ b/strictlocal/builder_test.go
@@ -1,0 +1,21 @@
+package strictlocal
+
+import "testing"
+
+func TestFilterIdentities(t *testing.T) {
+	list := []IdentityInfo{
+		{Address: "a", Stake: 12000, State: "Human", Penalty: "0"},
+		{Address: "b", Stake: 9999, State: "Human", Penalty: "0"},
+		{Address: "c", Stake: 10000, State: "Verified", Penalty: "0"},
+		{Address: "d", Stake: 10000, State: "Zombie", Penalty: "0"},
+		{Address: "e", Stake: 10000, State: "Verified", Penalty: "1"},
+		{Address: "f", Stake: 10000, State: "Newbie", Penalty: "0", Flags: []string{"AtLeastOneFlipReported"}},
+	}
+	out := filterIdentities(list, 11000)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 eligible, got %d", len(out))
+	}
+	if out[0].Address != "a" || out[1].Address != "c" {
+		t.Fatalf("unexpected addresses: %+v", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add README for strictserver and sample API HTML
- log whitelist builder steps and add concurrency with rate limit
- serve static files in strictserver and log HTTP actions
- test strict local filtering logic
- explicitly exclude Undefined state

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68601a03d9548320ace5111c47300ec7